### PR TITLE
feat: add security readiness guardrails

### DIFF
--- a/apps/desktop/src-tauri/src/rpc.rs
+++ b/apps/desktop/src-tauri/src/rpc.rs
@@ -287,6 +287,7 @@ pub struct VaultLockStatusRes {
     pub unlocked: bool,
     pub mode: String,
     pub key_reference: Option<String>,
+    pub state: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1337,6 +1338,7 @@ fn map_lock_status(status: kc_core::rpc_service::VaultDbLockStatus) -> VaultLock
         unlocked: status.unlocked,
         mode: status.mode,
         key_reference: status.key_reference,
+        state: status.state,
     }
 }
 

--- a/apps/desktop/src-tauri/tests/rpc.rs
+++ b/apps/desktop/src-tauri/tests/rpc.rs
@@ -251,6 +251,7 @@ fn rpc_vault_lock_status_unlock_and_lock_round_trip() {
         RpcResponse::Ok { data } => {
             assert!(!data.db_encryption_enabled);
             assert!(data.unlocked);
+            assert_eq!(data.state, "disabled_plaintext");
         }
         RpcResponse::Err { error } => panic!("lock status failed: {}", error.code),
     }

--- a/apps/desktop/ui/src/api/rpc.ts
+++ b/apps/desktop/ui/src/api/rpc.ts
@@ -190,6 +190,7 @@ export type VaultLockStatusRes = {
   unlocked: boolean;
   mode: string;
   key_reference: string | null;
+  state: string;
 };
 export type VaultUnlockReq = { vault_path: string; passphrase: string };
 export type VaultUnlockRes = { status: VaultLockStatusRes };

--- a/apps/desktop/ui/test/features.test.ts
+++ b/apps/desktop/ui/test/features.test.ts
@@ -175,7 +175,8 @@ function mockApi(): DesktopRpcApi {
         db_encryption_enabled: true,
         unlocked: true,
         mode: "sqlcipher_v4",
-        key_reference: "vaultdb:v1"
+        key_reference: "vaultdb:v1",
+        state: "migrated_unlocked"
       }),
     vaultUnlock: () =>
       ok({
@@ -183,7 +184,8 @@ function mockApi(): DesktopRpcApi {
           db_encryption_enabled: true,
           unlocked: true,
           mode: "sqlcipher_v4",
-          key_reference: "vaultdb:v1"
+          key_reference: "vaultdb:v1",
+          state: "migrated_unlocked"
         }
       }),
     vaultLock: () =>
@@ -192,7 +194,8 @@ function mockApi(): DesktopRpcApi {
           db_encryption_enabled: true,
           unlocked: false,
           mode: "sqlcipher_v4",
-          key_reference: "vaultdb:v1"
+          key_reference: "vaultdb:v1",
+          state: "migrated_locked"
         }
       }),
     vaultEncryptionStatus: () =>

--- a/crates/kc_cli/src/commands/index.rs
+++ b/crates/kc_cli/src/commands/index.rs
@@ -2,11 +2,12 @@ use kc_core::app_error::{AppError, AppResult};
 use kc_core::canonical::load_canonical_text;
 use kc_core::db::open_db;
 use kc_core::object_store::ObjectStore;
+use kc_core::resource_limits::{VECTOR_REBUILD_MAX_ROWS, VECTOR_ROW_MAX_TEXT_BYTES};
 use kc_core::types::{ChunkId, DocId};
 use kc_core::vault::{vault_open, vault_paths};
 use kc_index::embedding::{Embedder, EmbeddingIdentity};
 use kc_index::fts::{rebuild_rows, FtsRow};
-use kc_index::vector::{LanceDbVectorIndex, VectorRow};
+use kc_index::vector::{LanceDbVectorIndex, VectorResourceLimits, VectorRow};
 use std::path::Path;
 
 struct DeterministicEmbedder;
@@ -181,7 +182,13 @@ pub fn run_rebuild(vault_path: &str) -> AppResult<()> {
 
     let vectors_path = paths.vectors_dir.join("lancedb-v1");
     let mut vector_index = LanceDbVectorIndex::open(embedder, vectors_path)?;
-    vector_index.upsert_rows(vector_rows)?;
+    vector_index.upsert_rows_with_limits(
+        vector_rows,
+        Some(VectorResourceLimits {
+            max_rows: VECTOR_REBUILD_MAX_ROWS,
+            max_text_bytes_per_row: VECTOR_ROW_MAX_TEXT_BYTES,
+        }),
+    )?;
 
     println!("index rebuild completed");
     Ok(())

--- a/crates/kc_cli/src/commands/ingest.rs
+++ b/crates/kc_cli/src/commands/ingest.rs
@@ -1,7 +1,8 @@
 use kc_core::app_error::{AppError, AppResult};
 use kc_core::db::open_db;
-use kc_core::ingest::{ingest_bytes, IngestBytesReq};
+use kc_core::ingest::{ingest_bytes_with_limits, validate_scan_folder_files, IngestBytesReq};
 use kc_core::object_store::ObjectStore;
+use kc_core::resource_limits::{ingest_single_file_limits, scan_folder_limits};
 use kc_core::vault::{vault_open, vault_paths};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -53,7 +54,7 @@ fn ingest_one(vault_path: &Path, file_path: &Path, source_kind: &str) -> AppResu
     })?;
 
     let now = now_ms();
-    let doc = ingest_bytes(
+    let doc = ingest_bytes_with_limits(
         &db,
         &store,
         IngestBytesReq {
@@ -64,6 +65,7 @@ fn ingest_one(vault_path: &Path, file_path: &Path, source_kind: &str) -> AppResu
             source_path: file_path.to_str(),
             now_ms: now,
         },
+        ingest_single_file_limits(),
     )?;
 
     println!("ingested {} -> {}", file_path.display(), doc.doc_id.0);
@@ -71,7 +73,9 @@ fn ingest_one(vault_path: &Path, file_path: &Path, source_kind: &str) -> AppResu
 }
 
 pub fn ingest_scan_folder(vault_path: &str, scan_root: &str, source_kind: &str) -> AppResult<()> {
-    let mut files: Vec<PathBuf> = walkdir::WalkDir::new(scan_root)
+    let scan_root_path = Path::new(scan_root);
+    let mut files: Vec<PathBuf> = walkdir::WalkDir::new(scan_root_path)
+        .follow_links(false)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
@@ -79,6 +83,7 @@ pub fn ingest_scan_folder(vault_path: &str, scan_root: &str, source_kind: &str) 
         .collect();
 
     files.sort();
+    validate_scan_folder_files(scan_root_path, &files, scan_folder_limits())?;
     for file in files {
         ingest_one(Path::new(vault_path), &file, source_kind)?;
     }
@@ -129,4 +134,41 @@ pub fn ingest_inbox_once(vault_path: &str, file_path: &str, source_kind: &str) -
 
     println!("moved {} -> {}", file.display(), target.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ingest_scan_folder;
+    use kc_core::db::open_db;
+    use kc_core::resource_limits::SCAN_FOLDER_MAX_DEPTH;
+    use kc_core::vault::vault_init;
+
+    #[test]
+    fn cli_scan_folder_resource_limit_rejects_deep_generated_tree_before_ingesting() {
+        let root = tempfile::tempdir().expect("tempdir").keep();
+        let vault_path = root.join("vault");
+        let scan_root = root.join("scan");
+        vault_init(&vault_path, "demo", 1).expect("vault init");
+
+        let mut deep = scan_root.clone();
+        for idx in 0..SCAN_FOLDER_MAX_DEPTH {
+            deep = deep.join(format!("d{idx}"));
+        }
+        std::fs::create_dir_all(&deep).expect("create deep tree");
+        std::fs::write(deep.join("too-deep.txt"), b"generated").expect("write generated file");
+
+        let err = ingest_scan_folder(
+            &vault_path.to_string_lossy(),
+            &scan_root.to_string_lossy(),
+            "generated-fixture",
+        )
+        .expect_err("deep generated scan tree should fail");
+        assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+
+        let conn = open_db(&vault_path.join("db/knowledge.sqlite")).expect("open db");
+        let docs_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM docs", [], |r| r.get(0))
+            .expect("docs count");
+        assert_eq!(docs_count, 0);
+    }
 }

--- a/crates/kc_cli/src/commands/vault.rs
+++ b/crates/kc_cli/src/commands/vault.rs
@@ -183,9 +183,11 @@ pub fn run_db_encrypt_status(vault_path: &str) -> AppResult<()> {
                 "mode": status.mode,
                 "key_reference": status.key_reference,
                 "unlocked": status.unlocked,
+                "state": status.state,
                 "lock_status": {
                     "db_encryption_enabled": lock_status.db_encryption_enabled,
                     "unlocked": lock_status.unlocked,
+                    "state": lock_status.state,
                 }
             }
         }))
@@ -204,6 +206,7 @@ pub fn run_db_encrypt_enable(vault_path: &str, passphrase_env: &str) -> AppResul
             "enabled": status.enabled,
             "mode": status.mode,
             "unlocked": status.unlocked,
+            "state": status.state,
         }))
         .unwrap_or_else(|_| "{}".to_string())
     );
@@ -227,6 +230,7 @@ pub fn run_db_encrypt_migrate(
                 "enabled": out.status.enabled,
                 "mode": out.status.mode,
                 "unlocked": out.status.unlocked,
+                "state": out.status.state,
             }
         }))
         .unwrap_or_else(|_| "{}".to_string())
@@ -564,9 +568,12 @@ mod tests {
         let status_enabled = vault_db_encrypt_status_service(&root).expect("db status enabled");
         assert!(status_enabled.enabled);
         assert!(status_enabled.unlocked);
+        assert_eq!(status_enabled.state, "migrated_unlocked");
 
         run_db_encrypt_migrate(root.to_string_lossy().as_ref(), &env_name, 2)
             .expect("migrate db encryption");
+        let status_migrated = vault_db_encrypt_status_service(&root).expect("db status migrated");
+        assert_eq!(status_migrated.state, "migrated_unlocked");
         run_db_encrypt_status(root.to_string_lossy().as_ref()).expect("db status command");
 
         std::env::set_var("KC_VAULT_DB_PASSPHRASE", "test-db-passphrase");

--- a/crates/kc_core/src/db.rs
+++ b/crates/kc_core/src/db.rs
@@ -8,11 +8,33 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 const LATEST_SCHEMA_VERSION: i64 = 11;
+const SQLITE_HEADER: &[u8; 16] = b"SQLite format 3\0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DbMigrationOutcome {
     Migrated,
     AlreadyEncrypted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DbEncryptionDerivedState {
+    DisabledPlaintext,
+    PendingMigration,
+    MigratedLocked,
+    MigratedUnlocked,
+    MigrationFailedRecoverable,
+}
+
+impl DbEncryptionDerivedState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DisabledPlaintext => "disabled_plaintext",
+            Self::PendingMigration => "pending_migration",
+            Self::MigratedLocked => "migrated_locked",
+            Self::MigratedUnlocked => "migrated_unlocked",
+            Self::MigrationFailedRecoverable => "migration_failed_recoverable",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -100,6 +122,51 @@ fn passphrase_from_session(db_path: &Path) -> Option<String> {
     let key = normalize_session_key(&vault_root);
     let sessions = db_unlock_sessions().lock().ok()?;
     sessions.get(&key).cloned()
+}
+
+fn has_plaintext_sqlite_header(db_path: &Path) -> AppResult<bool> {
+    match fs::read(db_path) {
+        Ok(bytes) => Ok(bytes.starts_with(SQLITE_HEADER)),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(true),
+        Err(e) => Err(AppError::new(
+            "KC_DB_OPEN_FAILED",
+            "db",
+            "failed reading database header",
+            false,
+            serde_json::json!({ "error": e.to_string(), "path": db_path }),
+        )),
+    }
+}
+
+pub fn derive_db_encryption_state(
+    _vault_path: &Path,
+    db_path: &Path,
+    enabled: bool,
+) -> AppResult<DbEncryptionDerivedState> {
+    let tmp_path = db_path.with_extension("sqlcipher.tmp");
+    let bak_path = db_path.with_extension("pre-sqlcipher.bak");
+    if tmp_path.exists() || bak_path.exists() {
+        return Ok(DbEncryptionDerivedState::MigrationFailedRecoverable);
+    }
+
+    if !enabled {
+        return Ok(DbEncryptionDerivedState::DisabledPlaintext);
+    }
+
+    if has_plaintext_sqlite_header(db_path)? {
+        return Ok(DbEncryptionDerivedState::PendingMigration);
+    }
+
+    let passphrase = passphrase_from_session(db_path).or_else(passphrase_from_env);
+    let Some(passphrase) = passphrase else {
+        return Ok(DbEncryptionDerivedState::MigratedLocked);
+    };
+
+    match verify_db_passphrase(db_path, &passphrase) {
+        Ok(()) => Ok(DbEncryptionDerivedState::MigratedUnlocked),
+        Err(err) if err.code == "KC_DB_KEY_INVALID" => Ok(DbEncryptionDerivedState::MigratedLocked),
+        Err(err) => Err(err),
+    }
 }
 
 fn validate_key_on_connection(conn: &Connection, passphrase: &str) -> AppResult<()> {

--- a/crates/kc_core/src/ingest.rs
+++ b/crates/kc_core/src/ingest.rs
@@ -2,6 +2,7 @@ use crate::app_error::{AppError, AppResult};
 use crate::events::append_event;
 use crate::types::{DocId, ObjectHash};
 use rusqlite::{params, Connection};
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct IngestedDoc {
@@ -20,6 +21,117 @@ pub struct IngestBytesReq<'a> {
     pub effective_ts_ms: i64,
     pub source_path: Option<&'a str>,
     pub now_ms: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IngestResourceLimits {
+    pub max_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ScanFolderResourceLimits {
+    pub max_files: usize,
+    pub max_depth: usize,
+    pub max_bytes_per_file: usize,
+}
+
+fn resource_limit_error(category: &str, message: &str, details: serde_json::Value) -> AppError {
+    AppError::new(
+        "KC_RESOURCE_LIMIT_EXCEEDED",
+        category,
+        message,
+        false,
+        details,
+    )
+}
+
+pub fn validate_ingest_bytes_limits(
+    bytes_len: usize,
+    limits: IngestResourceLimits,
+) -> AppResult<()> {
+    if bytes_len > limits.max_bytes {
+        return Err(resource_limit_error(
+            "ingest",
+            "ingest payload exceeds configured byte limit",
+            serde_json::json!({
+                "bytes": bytes_len,
+                "max_bytes": limits.max_bytes,
+            }),
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_scan_folder_files(
+    scan_root: &Path,
+    files: &[PathBuf],
+    limits: ScanFolderResourceLimits,
+) -> AppResult<()> {
+    if files.len() > limits.max_files {
+        return Err(resource_limit_error(
+            "ingest",
+            "scan-folder exceeds configured file-count limit",
+            serde_json::json!({
+                "files": files.len(),
+                "max_files": limits.max_files,
+                "scan_root": scan_root,
+            }),
+        ));
+    }
+
+    for file in files {
+        let depth = file
+            .strip_prefix(scan_root)
+            .ok()
+            .map(|rel| rel.components().count())
+            .unwrap_or_else(|| file.components().count());
+        if depth > limits.max_depth {
+            return Err(resource_limit_error(
+                "ingest",
+                "scan-folder file exceeds configured traversal depth",
+                serde_json::json!({
+                    "path": file,
+                    "depth": depth,
+                    "max_depth": limits.max_depth,
+                    "scan_root": scan_root,
+                }),
+            ));
+        }
+
+        let metadata = std::fs::metadata(file).map_err(|e| {
+            AppError::new(
+                "KC_INGEST_READ_FAILED",
+                "ingest",
+                "failed reading scan file metadata",
+                false,
+                serde_json::json!({ "error": e.to_string(), "path": file }),
+            )
+        })?;
+        let bytes = metadata.len() as usize;
+        if bytes > limits.max_bytes_per_file {
+            return Err(resource_limit_error(
+                "ingest",
+                "scan-folder file exceeds configured byte limit",
+                serde_json::json!({
+                    "path": file,
+                    "bytes": bytes,
+                    "max_bytes_per_file": limits.max_bytes_per_file,
+                }),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn ingest_bytes_with_limits(
+    conn: &Connection,
+    object_store: &crate::object_store::ObjectStore,
+    req: IngestBytesReq<'_>,
+    limits: IngestResourceLimits,
+) -> AppResult<IngestedDoc> {
+    validate_ingest_bytes_limits(req.bytes.len(), limits)?;
+    ingest_bytes(conn, object_store, req)
 }
 
 pub fn ingest_bytes(

--- a/crates/kc_core/src/lib.rs
+++ b/crates/kc_core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod recovery_escrow_gcp;
 pub mod recovery_escrow_hsm;
 pub mod recovery_escrow_local;
 pub mod recovery_escrow_private_kms;
+pub mod resource_limits;
 pub mod retrieval;
 pub mod rpc_service;
 pub mod services;

--- a/crates/kc_core/src/recovery.rs
+++ b/crates/kc_core/src/recovery.rs
@@ -417,6 +417,8 @@ pub fn verify_recovery_bundle(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::open_db;
+    use crate::object_store::{ObjectStore, ObjectStoreEncryptionContext};
 
     #[test]
     fn recovery_blob_decrypts_to_original_passphrase() {
@@ -438,5 +440,84 @@ mod tests {
         .expect("decrypt blob");
 
         assert_eq!(restored, b"vault-passphrase");
+    }
+
+    #[test]
+    fn recovery_restore_drill_unlocks_generated_encrypted_fixture() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("db/knowledge.sqlite");
+        let conn = open_db(&db_path).expect("open db");
+        let objects_dir = root.path().join("store/objects");
+        let vault_id = "vault-drill";
+        let vault_passphrase = "vault-passphrase-for-generated-drill";
+        let key_reference = format!("vault:{vault_id}");
+
+        let key = crate::object_store::derive_object_store_key(
+            vault_passphrase,
+            "vault-kdf-salt-v1",
+            4096,
+            2,
+            1,
+        )
+        .expect("derive fixture key");
+        let encrypted_store = ObjectStore::with_encryption(
+            objects_dir.clone(),
+            ObjectStoreEncryptionContext {
+                key,
+                key_reference: key_reference.clone(),
+            },
+        );
+        let payload = b"generated recovery drill payload";
+        let hash = encrypted_store
+            .put_bytes(&conn, payload, 1)
+            .expect("write encrypted fixture object");
+
+        let generated = generate_recovery_bundle(
+            vault_id,
+            &root.path().join("recovery-out"),
+            vault_passphrase,
+            100,
+        )
+        .expect("generate recovery bundle");
+        let verified =
+            verify_recovery_bundle(vault_id, &generated.bundle_path, &generated.recovery_phrase)
+                .expect("verify recovery bundle");
+        assert_eq!(verified, generated.manifest);
+
+        let blob = fs::read(generated.bundle_path.join("key_blob.enc")).expect("read key blob");
+        let restored = decrypt_recovery_blob(
+            vault_id,
+            generated.manifest.created_at_ms,
+            &generated.recovery_phrase,
+            &blob,
+            &generated.bundle_path.join("key_blob.enc"),
+        )
+        .expect("restore passphrase from recovery bundle");
+        assert_eq!(restored, vault_passphrase.as_bytes());
+
+        let restored_passphrase =
+            String::from_utf8(restored).expect("restored passphrase is utf8 fixture");
+        let restored_key = crate::object_store::derive_object_store_key(
+            &restored_passphrase,
+            "vault-kdf-salt-v1",
+            4096,
+            2,
+            1,
+        )
+        .expect("derive restored fixture key");
+        let restored_store = ObjectStore::with_encryption(
+            objects_dir,
+            ObjectStoreEncryptionContext {
+                key: restored_key,
+                key_reference,
+            },
+        );
+
+        assert_eq!(
+            restored_store
+                .get_bytes(&hash)
+                .expect("restored passphrase decrypts object"),
+            payload
+        );
     }
 }

--- a/crates/kc_core/src/resource_limits.rs
+++ b/crates/kc_core/src/resource_limits.rs
@@ -1,0 +1,37 @@
+use crate::ingest::{IngestResourceLimits, ScanFolderResourceLimits};
+use crate::sync::SyncSnapshotResourceLimits;
+
+pub const MIB: usize = 1024 * 1024;
+
+pub const INGEST_SINGLE_FILE_MAX_BYTES: usize = 100 * MIB;
+pub const SCAN_FOLDER_MAX_FILES: usize = 10_000;
+pub const SCAN_FOLDER_MAX_DEPTH: usize = 12;
+pub const PDF_INPUT_MAX_BYTES: usize = 100 * MIB;
+pub const PDF_EXTRACTED_TEXT_MAX_BYTES: usize = 25 * MIB;
+pub const SYNC_SNAPSHOT_MAX_ARCHIVE_BYTES: usize = 2 * 1024 * MIB;
+pub const SYNC_SNAPSHOT_MAX_ENTRIES: usize = 250_000;
+pub const SYNC_SNAPSHOT_MAX_ENTRY_BYTES: u64 = (250 * MIB) as u64;
+pub const VECTOR_REBUILD_MAX_ROWS: usize = 100_000;
+pub const VECTOR_ROW_MAX_TEXT_BYTES: usize = MIB;
+
+pub fn ingest_single_file_limits() -> IngestResourceLimits {
+    IngestResourceLimits {
+        max_bytes: INGEST_SINGLE_FILE_MAX_BYTES,
+    }
+}
+
+pub fn scan_folder_limits() -> ScanFolderResourceLimits {
+    ScanFolderResourceLimits {
+        max_files: SCAN_FOLDER_MAX_FILES,
+        max_depth: SCAN_FOLDER_MAX_DEPTH,
+        max_bytes_per_file: INGEST_SINGLE_FILE_MAX_BYTES,
+    }
+}
+
+pub fn sync_snapshot_limits() -> SyncSnapshotResourceLimits {
+    SyncSnapshotResourceLimits {
+        max_archive_bytes: SYNC_SNAPSHOT_MAX_ARCHIVE_BYTES,
+        max_entries: SYNC_SNAPSHOT_MAX_ENTRIES,
+        max_entry_bytes: SYNC_SNAPSHOT_MAX_ENTRY_BYTES,
+    }
+}

--- a/crates/kc_core/src/rpc_service.rs
+++ b/crates/kc_core/src/rpc_service.rs
@@ -1,11 +1,12 @@
 use crate::app_error::{AppError, AppResult};
 use crate::canonical::load_canonical_text;
 use crate::db::{
-    db_is_unlocked, db_lock, db_unlock, migrate_db_to_sqlcipher, open_db, DbMigrationOutcome,
+    db_is_unlocked, db_lock, db_unlock, derive_db_encryption_state, migrate_db_to_sqlcipher,
+    open_db, DbMigrationOutcome,
 };
 use crate::events::append_event;
 use crate::hashing::blake3_hex_prefixed;
-use crate::ingest::{ingest_bytes, IngestBytesReq};
+use crate::ingest::{ingest_bytes_with_limits, validate_scan_folder_files, IngestBytesReq};
 use crate::lineage_governance::{
     lineage_lock_acquire_scope, lineage_role_grant, lineage_role_list, lineage_role_revoke,
     LineageRoleBindingV2, LineageScopeLockLeaseV2,
@@ -32,6 +33,7 @@ use crate::recovery_escrow_local::LocalRecoveryEscrowProvider;
 use crate::recovery_escrow_private_kms::{
     PrivateKmsRecoveryEscrowConfig, PrivateKmsRecoveryEscrowProvider,
 };
+use crate::resource_limits::{ingest_single_file_limits, scan_folder_limits};
 use crate::trust::{
     trust_device_init, trust_device_list, trust_device_verify, TrustedDeviceRecord,
 };
@@ -171,6 +173,7 @@ pub struct VaultDbLockStatus {
     pub unlocked: bool,
     pub mode: String,
     pub key_reference: Option<String>,
+    pub state: String,
 }
 
 #[derive(Debug, Clone)]
@@ -179,6 +182,7 @@ pub struct VaultDbEncryptStatus {
     pub mode: String,
     pub key_reference: Option<String>,
     pub unlocked: bool,
+    pub state: String,
 }
 
 #[derive(Debug, Clone)]
@@ -740,12 +744,14 @@ pub fn ingest_scan_folder_service(
     let store = object_store_without_passphrase(&vault, vault_path)?;
 
     let mut files: Vec<PathBuf> = walkdir::WalkDir::new(scan_root)
+        .follow_links(false)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
         .map(|e| e.path().to_path_buf())
         .collect();
     files.sort();
+    validate_scan_folder_files(scan_root, &files, scan_folder_limits())?;
 
     let mut ingested = 0i64;
     for path in files {
@@ -758,7 +764,7 @@ pub fn ingest_scan_folder_service(
                 serde_json::json!({ "error": e.to_string(), "path": path }),
             )
         })?;
-        ingest_bytes(
+        ingest_bytes_with_limits(
             &conn,
             &store,
             IngestBytesReq {
@@ -769,6 +775,7 @@ pub fn ingest_scan_folder_service(
                 source_path: Some(&path.to_string_lossy()),
                 now_ms,
             },
+            ingest_single_file_limits(),
         )?;
         ingested += 1;
     }
@@ -796,7 +803,7 @@ pub fn ingest_inbox_start_service(
         )
     })?;
 
-    let out = ingest_bytes(
+    let out = ingest_bytes_with_limits(
         &conn,
         &store,
         IngestBytesReq {
@@ -807,6 +814,7 @@ pub fn ingest_inbox_start_service(
             source_path: Some(&file_path.to_string_lossy()),
             now_ms,
         },
+        ingest_single_file_limits(),
     )?;
 
     let job_id = format!(
@@ -2023,7 +2031,9 @@ pub fn vault_recovery_escrow_restore_service(
 fn db_lock_status_for_vault(
     vault_path: &Path,
     vault: &crate::vault::VaultJsonV2,
-) -> VaultDbLockStatus {
+) -> AppResult<VaultDbLockStatus> {
+    let db_path = vault_path.join(vault.db.relative_path.clone());
+    let state = derive_db_encryption_state(vault_path, &db_path, vault.db_encryption.enabled)?;
     let unlocked = if vault.db_encryption.enabled {
         db_is_unlocked(vault_path)
             || std::env::var("KC_VAULT_DB_PASSPHRASE").is_ok()
@@ -2031,24 +2041,27 @@ fn db_lock_status_for_vault(
     } else {
         true
     };
-    VaultDbLockStatus {
+    Ok(VaultDbLockStatus {
         db_encryption_enabled: vault.db_encryption.enabled,
         unlocked,
         mode: vault.db_encryption.mode.clone(),
         key_reference: vault.db_encryption.key_reference.clone(),
-    }
+        state: state.as_str().to_string(),
+    })
 }
 
 fn db_encrypt_status_for_vault(
     vault_path: &Path,
     vault: &crate::vault::VaultJsonV2,
-) -> VaultDbEncryptStatus {
-    VaultDbEncryptStatus {
+) -> AppResult<VaultDbEncryptStatus> {
+    let lock_status = db_lock_status_for_vault(vault_path, vault)?;
+    Ok(VaultDbEncryptStatus {
         enabled: vault.db_encryption.enabled,
         mode: vault.db_encryption.mode.clone(),
         key_reference: vault.db_encryption.key_reference.clone(),
-        unlocked: db_lock_status_for_vault(vault_path, vault).unlocked,
-    }
+        unlocked: lock_status.unlocked,
+        state: lock_status.state,
+    })
 }
 
 fn ensure_passphrase_not_empty(passphrase: &str) -> AppResult<()> {
@@ -2066,29 +2079,29 @@ fn ensure_passphrase_not_empty(passphrase: &str) -> AppResult<()> {
 
 pub fn vault_lock_status_service(vault_path: &Path) -> AppResult<VaultDbLockStatus> {
     let vault = vault_open(vault_path)?;
-    Ok(db_lock_status_for_vault(vault_path, &vault))
+    db_lock_status_for_vault(vault_path, &vault)
 }
 
 pub fn vault_unlock_service(vault_path: &Path, passphrase: &str) -> AppResult<VaultDbLockStatus> {
     ensure_passphrase_not_empty(passphrase)?;
     let vault = vault_open(vault_path)?;
     if !vault.db_encryption.enabled {
-        return Ok(db_lock_status_for_vault(vault_path, &vault));
+        return db_lock_status_for_vault(vault_path, &vault);
     }
     let db_path = vault_path.join(vault.db.relative_path.clone());
     db_unlock(vault_path, &db_path, passphrase)?;
-    Ok(db_lock_status_for_vault(vault_path, &vault))
+    db_lock_status_for_vault(vault_path, &vault)
 }
 
 pub fn vault_lock_service(vault_path: &Path) -> AppResult<VaultDbLockStatus> {
     let vault = vault_open(vault_path)?;
     db_lock(vault_path)?;
-    Ok(db_lock_status_for_vault(vault_path, &vault))
+    db_lock_status_for_vault(vault_path, &vault)
 }
 
 pub fn vault_db_encrypt_status_service(vault_path: &Path) -> AppResult<VaultDbEncryptStatus> {
     let vault = vault_open(vault_path)?;
-    Ok(db_encrypt_status_for_vault(vault_path, &vault))
+    db_encrypt_status_for_vault(vault_path, &vault)
 }
 
 pub fn vault_db_encrypt_enable_service(
@@ -2106,7 +2119,7 @@ pub fn vault_db_encrypt_enable_service(
     }
     let db_path = vault_path.join(vault.db.relative_path.clone());
     db_unlock(vault_path, &db_path, passphrase)?;
-    Ok(db_encrypt_status_for_vault(vault_path, &vault))
+    db_encrypt_status_for_vault(vault_path, &vault)
 }
 
 pub fn vault_db_encrypt_migrate_service(
@@ -2152,7 +2165,7 @@ pub fn vault_db_encrypt_migrate_service(
         )
     })?;
     Ok(VaultDbEncryptMigrateResult {
-        status: db_encrypt_status_for_vault(vault_path, &vault),
+        status: db_encrypt_status_for_vault(vault_path, &vault)?,
         outcome: match migration_outcome {
             DbMigrationOutcome::Migrated => "migrated".to_string(),
             DbMigrationOutcome::AlreadyEncrypted => "already_encrypted".to_string(),

--- a/crates/kc_core/src/sync.rs
+++ b/crates/kc_core/src/sync.rs
@@ -3,6 +3,7 @@ use crate::canon_json::to_canonical_bytes;
 use crate::db::open_db;
 use crate::export::{export_bundle, ExportOptions};
 use crate::hashing::blake3_hex_prefixed;
+use crate::resource_limits::sync_snapshot_limits;
 use crate::sync_merge::{
     ensure_conservative_merge_safe, ensure_conservative_plus_v2_merge_safe,
     ensure_conservative_plus_v3_merge_safe, ensure_conservative_plus_v4_merge_safe,
@@ -25,6 +26,13 @@ const TRUST_MODEL_PASSPHRASE_V1: &str = "passphrase_v1";
 const S3_LOCK_KEY: &str = "locks/write.lock";
 const S3_LOCK_TTL_MS: i64 = 60_000;
 static SYNC_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy)]
+pub struct SyncSnapshotResourceLimits {
+    pub max_archive_bytes: usize,
+    pub max_entries: usize,
+    pub max_entry_bytes: u64,
+}
 
 fn next_sync_temp_suffix() -> u64 {
     SYNC_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -362,6 +370,27 @@ fn safe_zip_relative_path(name: &str) -> AppResult<PathBuf> {
 }
 
 fn unpack_zip_snapshot(zip_bytes: &[u8], output_dir: &Path) -> AppResult<()> {
+    unpack_zip_snapshot_with_limits(zip_bytes, output_dir, None)
+}
+
+fn unpack_zip_snapshot_with_limits(
+    zip_bytes: &[u8],
+    output_dir: &Path,
+    limits: Option<SyncSnapshotResourceLimits>,
+) -> AppResult<()> {
+    if let Some(limits) = limits {
+        if zip_bytes.len() > limits.max_archive_bytes {
+            return Err(sync_error(
+                "KC_RESOURCE_LIMIT_EXCEEDED",
+                "sync snapshot archive exceeds configured byte limit",
+                serde_json::json!({
+                    "bytes": zip_bytes.len(),
+                    "max_archive_bytes": limits.max_archive_bytes,
+                }),
+            ));
+        }
+    }
+
     fs::create_dir_all(output_dir).map_err(|e| {
         sync_error(
             "KC_SYNC_TARGET_INVALID",
@@ -389,6 +418,29 @@ fn unpack_zip_snapshot(zip_bytes: &[u8], output_dir: &Path) -> AppResult<()> {
         })?;
         if file.name().ends_with('/') {
             continue;
+        }
+        if let Some(limits) = limits {
+            if names.len() + 1 > limits.max_entries {
+                return Err(sync_error(
+                    "KC_RESOURCE_LIMIT_EXCEEDED",
+                    "sync snapshot zip exceeds configured entry limit",
+                    serde_json::json!({
+                        "entries": names.len() + 1,
+                        "max_entries": limits.max_entries,
+                    }),
+                ));
+            }
+            if file.size() > limits.max_entry_bytes {
+                return Err(sync_error(
+                    "KC_RESOURCE_LIMIT_EXCEEDED",
+                    "sync snapshot zip entry exceeds configured byte limit",
+                    serde_json::json!({
+                        "entry": file.name(),
+                        "bytes": file.size(),
+                        "max_entry_bytes": limits.max_entry_bytes,
+                    }),
+                ));
+            }
         }
         names.push(file.name().to_string());
     }
@@ -2021,7 +2073,7 @@ fn sync_pull_s3_target(
                 )
             })?;
         }
-        unpack_zip_snapshot(&zip_bytes, &unpack_dir)?;
+        unpack_zip_snapshot_with_limits(&zip_bytes, &unpack_dir, Some(sync_snapshot_limits()))?;
         apply_snapshot_to_vault(&unpack_dir, vault_path)?;
 
         let post_conn = open_db(&db_path)?;
@@ -2093,7 +2145,7 @@ pub fn sync_pull_target_with_mode(
 
 #[cfg(test)]
 mod tests {
-    use super::unpack_zip_snapshot;
+    use super::{unpack_zip_snapshot, unpack_zip_snapshot_with_limits, SyncSnapshotResourceLimits};
     use std::io::Write;
     use zip::write::SimpleFileOptions;
 
@@ -2139,5 +2191,48 @@ mod tests {
         unpack_zip_snapshot(&bytes, &out).expect("safe zip should unpack");
         assert!(out.join("manifest.json").exists());
         assert!(out.join("db/knowledge.sqlite").exists());
+    }
+
+    #[test]
+    fn unpack_zip_snapshot_limits_reject_generated_oversized_archive_without_writes() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let out = root.path().join("out");
+        let bytes = zip_bytes(&[("manifest.json", b"{\"schema\":1}")]);
+
+        let err = unpack_zip_snapshot_with_limits(
+            &bytes,
+            &out,
+            Some(SyncSnapshotResourceLimits {
+                max_archive_bytes: 8,
+                max_entries: 8,
+                max_entry_bytes: 1024,
+            }),
+        )
+        .expect_err("oversized archive should fail");
+
+        assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+        assert!(!out.exists());
+    }
+
+    #[test]
+    fn unpack_zip_snapshot_limits_reject_generated_entry_count_without_writes() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let out = root.path().join("out");
+        let bytes = zip_bytes(&[("manifest.json", b"{}"), ("db/knowledge.sqlite", b"db")]);
+
+        let err = unpack_zip_snapshot_with_limits(
+            &bytes,
+            &out,
+            Some(SyncSnapshotResourceLimits {
+                max_archive_bytes: bytes.len() + 1,
+                max_entries: 1,
+                max_entry_bytes: 1024,
+            }),
+        )
+        .expect_err("too many entries should fail");
+
+        assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+        assert!(!out.join("manifest.json").exists());
+        assert!(!out.join("db/knowledge.sqlite").exists());
     }
 }

--- a/crates/kc_core/tests/db_encryption.rs
+++ b/crates/kc_core/tests/db_encryption.rs
@@ -1,7 +1,8 @@
 use kc_core::db::{
-    db_is_unlocked, db_lock, db_unlock, migrate_db_to_sqlcipher, open_db, schema_version,
+    db_is_unlocked, db_lock, db_unlock, derive_db_encryption_state, migrate_db_to_sqlcipher,
+    open_db, schema_version, DbEncryptionDerivedState, DbMigrationOutcome,
 };
-use kc_core::vault::{vault_init, vault_paths, vault_save};
+use kc_core::vault::{vault_init, vault_open, vault_paths, vault_save};
 use std::sync::{Mutex, OnceLock};
 
 fn env_lock() -> &'static Mutex<()> {
@@ -23,6 +24,110 @@ fn db_encryption_requires_passphrase_when_enabled() {
 
     let err = open_db(&vault_paths(&root).db).expect_err("expected locked db error");
     assert_eq!(err.code, "KC_DB_LOCKED");
+}
+
+#[test]
+fn db_encryption_state_derives_disabled_and_pending_without_writes() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    vault_init(&root, "demo", 1).expect("vault init");
+    let db_path = vault_paths(&root).db;
+    let vault_before = std::fs::read(root.join("vault.json")).expect("read vault before");
+
+    let disabled =
+        derive_db_encryption_state(&root, &db_path, false).expect("derive disabled state");
+    assert_eq!(disabled, DbEncryptionDerivedState::DisabledPlaintext);
+
+    let pending = derive_db_encryption_state(&root, &db_path, true).expect("derive pending state");
+    assert_eq!(pending, DbEncryptionDerivedState::PendingMigration);
+
+    let vault_after = std::fs::read(root.join("vault.json")).expect("read vault after");
+    assert_eq!(vault_after, vault_before);
+}
+
+#[test]
+fn db_encryption_state_derives_migrated_lock_states() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    vault_init(&root, "demo", 1).expect("vault init");
+    let db_path = vault_paths(&root).db;
+    migrate_db_to_sqlcipher(&db_path, "migration-passphrase").expect("migrate db");
+
+    let locked =
+        derive_db_encryption_state(&root, &db_path, true).expect("derive locked migrated state");
+    assert_eq!(locked, DbEncryptionDerivedState::MigratedLocked);
+
+    std::env::set_var("KC_VAULT_DB_PASSPHRASE", "wrong-passphrase");
+    let wrong_key =
+        derive_db_encryption_state(&root, &db_path, true).expect("derive wrong-key migrated state");
+    assert_eq!(wrong_key, DbEncryptionDerivedState::MigratedLocked);
+
+    std::env::set_var("KC_VAULT_DB_PASSPHRASE", "migration-passphrase");
+    let unlocked =
+        derive_db_encryption_state(&root, &db_path, true).expect("derive unlocked migrated state");
+    assert_eq!(unlocked, DbEncryptionDerivedState::MigratedUnlocked);
+
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+}
+
+#[test]
+fn db_encryption_state_reports_recoverable_artifacts_first() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    vault_init(&root, "demo", 1).expect("vault init");
+    let db_path = vault_paths(&root).db;
+    std::fs::write(db_path.with_extension("sqlcipher.tmp"), b"tmp").expect("write tmp artifact");
+
+    let state = derive_db_encryption_state(&root, &db_path, false).expect("derive artifact state");
+    assert_eq!(state, DbEncryptionDerivedState::MigrationFailedRecoverable);
+}
+
+#[test]
+fn db_encryption_rejects_unsupported_mode_before_unlock() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    let mut vault = vault_init(&root, "demo", 1).expect("vault init");
+    vault.db_encryption.enabled = true;
+    vault.db_encryption.mode = "sqlcipher_v3".to_string();
+    vault.db_encryption.key_reference = Some(format!("vaultdb:{}", vault.vault_id));
+    vault_save(&root, &vault).expect("vault save");
+
+    let open_err = vault_open(&root).expect_err("vault_open should reject unsupported mode");
+    assert_eq!(open_err.code, "KC_DB_ENCRYPTION_UNSUPPORTED");
+
+    let db_err =
+        open_db(&vault_paths(&root).db).expect_err("open_db should reject unsupported mode");
+    assert_eq!(db_err.code, "KC_DB_ENCRYPTION_UNSUPPORTED");
+}
+
+#[test]
+fn db_encryption_rejects_unsupported_kdf_algorithm() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    let mut vault = vault_init(&root, "demo", 1).expect("vault init");
+    vault.db_encryption.enabled = true;
+    vault.db_encryption.kdf.algorithm = "argon2id".to_string();
+    vault.db_encryption.key_reference = Some(format!("vaultdb:{}", vault.vault_id));
+    vault_save(&root, &vault).expect("vault save");
+
+    let err = vault_open(&root).expect_err("vault_open should reject unsupported db kdf");
+    assert_eq!(err.code, "KC_DB_ENCRYPTION_UNSUPPORTED");
 }
 
 #[test]
@@ -87,7 +192,9 @@ fn db_migration_to_sqlcipher_requires_valid_key_after_migrate() {
     let db_path = vault_paths(&root).db;
 
     let outcome = migrate_db_to_sqlcipher(&db_path, "migration-passphrase").expect("migrate db");
-    assert_eq!(outcome, kc_core::db::DbMigrationOutcome::Migrated);
+    assert_eq!(outcome, DbMigrationOutcome::Migrated);
+    assert!(!db_path.with_extension("sqlcipher.tmp").exists());
+    assert!(!db_path.with_extension("pre-sqlcipher.bak").exists());
 
     vault.db_encryption.enabled = true;
     vault.db_encryption.key_reference = Some(format!("vaultdb:{}", vault.vault_id));
@@ -106,4 +213,29 @@ fn db_migration_to_sqlcipher_requires_valid_key_after_migrate() {
 
     std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
     std::env::remove_var("KC_VAULT_PASSPHRASE");
+}
+
+#[test]
+fn db_migration_to_sqlcipher_is_idempotent_after_encrypting() {
+    let _guard = env_lock().lock().expect("env lock");
+    std::env::remove_var("KC_VAULT_DB_PASSPHRASE");
+    std::env::remove_var("KC_VAULT_PASSPHRASE");
+
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    vault_init(&root, "demo", 1).expect("vault init");
+    let db_path = vault_paths(&root).db;
+
+    let migrated = migrate_db_to_sqlcipher(&db_path, "migration-passphrase")
+        .expect("first migration should encrypt");
+    assert_eq!(migrated, DbMigrationOutcome::Migrated);
+
+    let already = migrate_db_to_sqlcipher(&db_path, "migration-passphrase")
+        .expect("second migration should detect encrypted db");
+    assert_eq!(already, DbMigrationOutcome::AlreadyEncrypted);
+
+    let wrong =
+        migrate_db_to_sqlcipher(&db_path, "wrong-passphrase").expect_err("wrong key should fail");
+    assert_eq!(wrong.code, "KC_DB_KEY_INVALID");
+    assert!(!db_path.with_extension("sqlcipher.tmp").exists());
+    assert!(!db_path.with_extension("pre-sqlcipher.bak").exists());
 }

--- a/crates/kc_core/tests/ingest.rs
+++ b/crates/kc_core/tests/ingest.rs
@@ -1,6 +1,11 @@
 use kc_core::db::open_db;
-use kc_core::ingest::{ingest_bytes, IngestBytesReq};
+use kc_core::ingest::{
+    ingest_bytes, ingest_bytes_with_limits, IngestBytesReq, IngestResourceLimits,
+};
 use kc_core::object_store::ObjectStore;
+use kc_core::resource_limits::SCAN_FOLDER_MAX_DEPTH;
+use kc_core::rpc_service::ingest_scan_folder_service;
+use kc_core::vault::vault_init;
 
 #[test]
 fn ingest_is_idempotent_and_persists_doc_source() {
@@ -57,4 +62,63 @@ fn ingest_is_idempotent_and_persists_doc_source() {
         )
         .expect("doc source count");
     assert_eq!(src_count, 1);
+}
+
+#[test]
+fn ingest_resource_limit_rejects_oversized_generated_payload() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let conn = open_db(&temp.path().join("db/knowledge.sqlite")).expect("open db");
+    let store = ObjectStore::new(temp.path().join("store/objects"));
+    let payload = vec![b'a'; 16];
+
+    let err = ingest_bytes_with_limits(
+        &conn,
+        &store,
+        IngestBytesReq {
+            bytes: &payload,
+            mime: "text/plain",
+            source_kind: "generated-fixture",
+            effective_ts_ms: 100,
+            source_path: Some("/generated/oversized.txt"),
+            now_ms: 200,
+        },
+        IngestResourceLimits { max_bytes: 8 },
+    )
+    .expect_err("oversized generated payload should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+
+    let docs_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM docs", [], |r| r.get(0))
+        .expect("docs count");
+    let events_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+        .expect("events count");
+    assert_eq!(docs_count, 0);
+    assert_eq!(events_count, 0);
+}
+
+#[test]
+fn rpc_scan_folder_resource_limit_rejects_deep_generated_tree_before_ingesting() {
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    let vault_path = root.join("vault");
+    let scan_root = root.join("scan");
+    vault_init(&vault_path, "demo", 1).expect("vault init");
+
+    let mut deep = scan_root.clone();
+    for idx in 0..SCAN_FOLDER_MAX_DEPTH {
+        deep = deep.join(format!("d{idx}"));
+    }
+    std::fs::create_dir_all(&deep).expect("create deep tree");
+    std::fs::write(deep.join("too-deep.txt"), b"generated").expect("write generated file");
+
+    let err = ingest_scan_folder_service(&vault_path, &scan_root, "generated-fixture", 100)
+        .expect_err("deep generated scan tree should fail");
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+
+    let conn = open_db(&vault_path.join("db/knowledge.sqlite")).expect("open db");
+    let docs_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM docs", [], |r| r.get(0))
+        .expect("docs count");
+    assert_eq!(docs_count, 0);
 }

--- a/crates/kc_core/tests/recovery.rs
+++ b/crates/kc_core/tests/recovery.rs
@@ -74,6 +74,25 @@ fn recovery_verify_rejects_tampered_blob() {
 }
 
 #[test]
+fn recovery_verify_rejects_missing_bundle_files() {
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    let vault = vault_init(&root.join("vault"), "demo", 1).expect("vault init");
+    let output = root.join("recovery-out");
+
+    let generated = generate_recovery_bundle(&vault.vault_id, &output, "vault-passphrase", 100)
+        .expect("generate recovery");
+    std::fs::remove_file(generated.bundle_path.join("key_blob.enc")).expect("remove key blob");
+
+    let err = verify_recovery_bundle(
+        &vault.vault_id,
+        &generated.bundle_path,
+        &generated.recovery_phrase,
+    )
+    .expect_err("verify should fail");
+    assert_eq!(err.code, "KC_RECOVERY_BUNDLE_INVALID");
+}
+
+#[test]
 fn recovery_verify_rejects_matching_hash_for_undecryptable_blob() {
     let root = tempfile::tempdir().expect("tempdir").keep();
     let vault = vault_init(&root.join("vault"), "demo", 1).expect("vault init");

--- a/crates/kc_extract/src/pdf.rs
+++ b/crates/kc_extract/src/pdf.rs
@@ -6,10 +6,49 @@ pub struct PdfiumConfig {
     pub library_path: Option<String>,
 }
 
+#[derive(Debug, Clone)]
 pub struct PdfExtractOutput {
     pub text_with_page_markers: String,
     pub extracted_len: usize,
     pub extracted_alnum_ratio: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PdfResourceLimits {
+    pub max_input_bytes: usize,
+    pub max_extracted_bytes: usize,
+}
+
+fn enforce_pdf_input_limit(pdf_bytes: &[u8], limits: PdfResourceLimits) -> AppResult<()> {
+    if pdf_bytes.len() > limits.max_input_bytes {
+        return Err(AppError::new(
+            "KC_RESOURCE_LIMIT_EXCEEDED",
+            "extract",
+            "pdf input exceeds configured byte limit",
+            false,
+            serde_json::json!({
+                "bytes": pdf_bytes.len(),
+                "max_input_bytes": limits.max_input_bytes,
+            }),
+        ));
+    }
+    Ok(())
+}
+
+fn enforce_pdf_output_limit(text_len: usize, limits: PdfResourceLimits) -> AppResult<()> {
+    if text_len > limits.max_extracted_bytes {
+        return Err(AppError::new(
+            "KC_RESOURCE_LIMIT_EXCEEDED",
+            "extract",
+            "pdf extracted text exceeds configured byte limit",
+            false,
+            serde_json::json!({
+                "bytes": text_len,
+                "max_extracted_bytes": limits.max_extracted_bytes,
+            }),
+        ));
+    }
+    Ok(())
 }
 
 fn alnum_ratio(content: &str) -> f64 {
@@ -100,6 +139,18 @@ fn extract_pdf_via_pdfium(pdf_bytes: &[u8], cfg: &PdfiumConfig) -> AppResult<Str
 }
 
 pub fn extract_pdf_text(pdf_bytes: &[u8], cfg: &PdfiumConfig) -> AppResult<PdfExtractOutput> {
+    extract_pdf_text_with_limits(pdf_bytes, cfg, None)
+}
+
+pub fn extract_pdf_text_with_limits(
+    pdf_bytes: &[u8],
+    cfg: &PdfiumConfig,
+    limits: Option<PdfResourceLimits>,
+) -> AppResult<PdfExtractOutput> {
+    if let Some(limits) = limits {
+        enforce_pdf_input_limit(pdf_bytes, limits)?;
+    }
+
     let text = if pdf_bytes.starts_with(b"%PDF") {
         extract_pdf_via_pdfium(pdf_bytes, cfg)?
     } else {
@@ -116,6 +167,9 @@ pub fn extract_pdf_text(pdf_bytes: &[u8], cfg: &PdfiumConfig) -> AppResult<PdfEx
     };
 
     let ratio = alnum_ratio(&text);
+    if let Some(limits) = limits {
+        enforce_pdf_output_limit(text.len(), limits)?;
+    }
 
     Ok(PdfExtractOutput {
         extracted_len: text.len(),

--- a/crates/kc_extract/tests/golden_pdf.rs
+++ b/crates/kc_extract/tests/golden_pdf.rs
@@ -1,7 +1,9 @@
 use kc_core::services::{ExtractInput, ExtractService, ToolchainIdentity};
 use kc_core::types::DocId;
 use kc_extract::ocr::{ocr_pdf_via_images, should_run_ocr, OcrConfig};
-use kc_extract::pdf::{extract_pdf_text, PdfiumConfig};
+use kc_extract::pdf::{
+    extract_pdf_text, extract_pdf_text_with_limits, PdfResourceLimits, PdfiumConfig,
+};
 use kc_extract::DefaultExtractor;
 
 #[test]
@@ -75,4 +77,34 @@ fn golden_pdf_ocr_hard_fails_when_tesseract_missing() {
     .expect_err("missing tesseract command must hard-fail");
 
     assert_eq!(err.code, "KC_TESSERACT_UNAVAILABLE");
+}
+
+#[test]
+fn pdf_resource_limits_reject_generated_oversized_input() {
+    let err = extract_pdf_text_with_limits(
+        b"generated pdf-like bytes",
+        &PdfiumConfig { library_path: None },
+        Some(PdfResourceLimits {
+            max_input_bytes: 8,
+            max_extracted_bytes: 1024,
+        }),
+    )
+    .expect_err("oversized generated input should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+}
+
+#[test]
+fn pdf_resource_limits_reject_generated_oversized_extracted_text() {
+    let err = extract_pdf_text_with_limits(
+        b"generated extracted text body",
+        &PdfiumConfig { library_path: None },
+        Some(PdfResourceLimits {
+            max_input_bytes: 1024,
+            max_extracted_bytes: 8,
+        }),
+    )
+    .expect_err("oversized generated extracted text should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
 }

--- a/crates/kc_index/src/vector.rs
+++ b/crates/kc_index/src/vector.rs
@@ -26,6 +26,12 @@ pub struct VectorRow {
     pub vector: Vec<f32>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct VectorResourceLimits {
+    pub max_rows: usize,
+    pub max_text_bytes_per_row: usize,
+}
+
 pub struct LanceDbVectorIndex<E: Embedder> {
     embedder: E,
     db_root: PathBuf,
@@ -103,7 +109,46 @@ impl<E: Embedder> LanceDbVectorIndex<E> {
         Ok(instance)
     }
 
-    pub fn upsert_rows(&mut self, mut rows: Vec<VectorRow>) -> AppResult<()> {
+    pub fn upsert_rows(&mut self, rows: Vec<VectorRow>) -> AppResult<()> {
+        self.upsert_rows_with_limits(rows, None)
+    }
+
+    pub fn upsert_rows_with_limits(
+        &mut self,
+        mut rows: Vec<VectorRow>,
+        limits: Option<VectorResourceLimits>,
+    ) -> AppResult<()> {
+        if let Some(limits) = limits {
+            if rows.len() > limits.max_rows {
+                return Err(AppError::new(
+                    "KC_RESOURCE_LIMIT_EXCEEDED",
+                    "vector",
+                    "vector rows exceed configured row limit",
+                    false,
+                    serde_json::json!({
+                        "rows": rows.len(),
+                        "max_rows": limits.max_rows,
+                    }),
+                ));
+            }
+            if let Some(row) = rows
+                .iter()
+                .find(|row| row.text.len() > limits.max_text_bytes_per_row)
+            {
+                return Err(AppError::new(
+                    "KC_RESOURCE_LIMIT_EXCEEDED",
+                    "vector",
+                    "vector row text exceeds configured byte limit",
+                    false,
+                    serde_json::json!({
+                        "chunk_id": row.chunk_id.0,
+                        "bytes": row.text.len(),
+                        "max_text_bytes_per_row": limits.max_text_bytes_per_row,
+                    }),
+                ));
+            }
+        }
+
         for row in &rows {
             if row.vector.len() != self.identity.dims {
                 return Err(AppError::new(

--- a/crates/kc_index/tests/vector.rs
+++ b/crates/kc_index/tests/vector.rs
@@ -2,7 +2,7 @@ use kc_core::app_error::AppResult;
 use kc_core::index_traits::VectorIndex;
 use kc_core::types::{ChunkId, DocId};
 use kc_index::embedding::{Embedder, EmbeddingIdentity};
-use kc_index::vector::{LanceDbVectorIndex, VectorRow};
+use kc_index::vector::{LanceDbVectorIndex, VectorResourceLimits, VectorRow};
 
 struct DummyEmbedder;
 
@@ -67,4 +67,71 @@ fn vector_query_returns_ranked_hits() {
         .query("alpha", 10)
         .expect("query from reloaded index");
     assert_eq!(reloaded_hits[0].chunk_id.0, "c1");
+}
+
+#[test]
+fn vector_resource_limits_reject_generated_oversized_batch_without_persisting() {
+    let db_path = tempfile::tempdir()
+        .expect("tempdir")
+        .keep()
+        .join("vectors/lancedb-v1");
+    let mut index = LanceDbVectorIndex::open(DummyEmbedder, &db_path).expect("open index");
+
+    let err = index
+        .upsert_rows_with_limits(
+            vec![
+                VectorRow {
+                    chunk_id: ChunkId("c1".to_string()),
+                    doc_id: DocId("d1".to_string()),
+                    ordinal: 0,
+                    text: "alpha text".to_string(),
+                    vector: vec![1.0, 0.0],
+                },
+                VectorRow {
+                    chunk_id: ChunkId("c2".to_string()),
+                    doc_id: DocId("d2".to_string()),
+                    ordinal: 0,
+                    text: "beta text".to_string(),
+                    vector: vec![0.0, 1.0],
+                },
+            ],
+            Some(VectorResourceLimits {
+                max_rows: 1,
+                max_text_bytes_per_row: 1024,
+            }),
+        )
+        .expect_err("oversized generated vector batch should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+    let hits = index.query("alpha", 10).expect("query empty index");
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn vector_resource_limits_reject_generated_oversized_text_without_persisting() {
+    let db_path = tempfile::tempdir()
+        .expect("tempdir")
+        .keep()
+        .join("vectors/lancedb-v1");
+    let mut index = LanceDbVectorIndex::open(DummyEmbedder, &db_path).expect("open index");
+
+    let err = index
+        .upsert_rows_with_limits(
+            vec![VectorRow {
+                chunk_id: ChunkId("c1".to_string()),
+                doc_id: DocId("d1".to_string()),
+                ordinal: 0,
+                text: "alpha text".to_string(),
+                vector: vec![1.0, 0.0],
+            }],
+            Some(VectorResourceLimits {
+                max_rows: 8,
+                max_text_bytes_per_row: 4,
+            }),
+        )
+        .expect_err("oversized generated vector text should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+    let hits = index.query("alpha", 10).expect("query empty index");
+    assert!(hits.is_empty());
 }

--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -17,10 +17,20 @@ Capture the current security/readiness state after the June 2026 audit, first de
 | `cargo fmt --all -- --check` | PASS | Formatting gate. |
 | `cargo test --workspace --exclude apps_desktop_tauri` | PASS | Main Rust workspace gate. |
 | `cargo test -p kc_core` | PASS | Full core gate after sync-auth helper and recovery verifier hardening. |
+| `cargo test -p kc_core --test db_encryption` | PASS | DB encryption lifecycle coverage pins unsupported metadata, idempotent encrypted-state detection, wrong-key failure, and migration artifact cleanup. |
+| `cargo test -p kc_cli db_encrypt_enable_and_migrate_round_trip` | PASS | CLI DB-encryption status reports derived lifecycle state. |
 | `cargo test -p kc_cli recovery` | PASS | CLI recovery generate/verify and escrow restore paths accept the stricter verifier. |
 | `cargo test -p apps_desktop_tauri` | PASS | Desktop config, RPC, and RPC schema tests. |
 | `cargo build -p apps_desktop_tauri` | PASS | Tauri crate accepts the desktop config and capability manifest. |
+| `cargo test -p apps_desktop_tauri rpc_vault_lock_status_unlock_and_lock_round_trip` | PASS | Tauri lock-status RPC includes derived DB encryption state. |
 | `cargo test -p kc_core recovery` | PASS | Recovery verifier now proves decrypt/restore behavior and rejects matching-hash forged blobs. |
+| `cargo test -p kc_core recovery_restore_drill_unlocks_generated_encrypted_fixture` | PASS | Generated-fixture recovery drill proves restored passphrase decrypts an encrypted object-store fixture inside recovery module test scope. |
+| `cargo test -p kc_core ingest_resource_limit_rejects_oversized_generated_payload` | PASS | Opt-in ingest byte limit rejects generated oversized payload before events/docs writes. |
+| `cargo test -p kc_core unpack_zip_snapshot_limits` | PASS | Opt-in sync snapshot zip limits reject generated oversized archive/entry-count fixtures without extraction writes. |
+| `cargo test -p kc_extract pdf_resource_limits` | PASS | Opt-in PDF extraction limits reject generated oversized input and extracted text. |
+| `cargo test -p kc_index vector_resource_limits` | PASS | Opt-in vector limits reject generated oversized batch/text fixtures without persisting rows. |
+| `cargo test -p kc_core rpc_scan_folder_resource_limit_rejects_deep_generated_tree_before_ingesting` | PASS | Core/RPC scan-folder boundary enforces production depth defaults before doc writes. |
+| `cargo test -p kc_cli cli_scan_folder_resource_limit_rejects_deep_generated_tree_before_ingesting` | PASS | CLI scan-folder enforces production depth defaults before doc writes. |
 | `node ./scripts/audit-rust.mjs` | PASS | Zero vulnerabilities; 16 reviewed informational warnings remain with `review_by` `2026-07-19`. |
 | `node ./scripts/dependency-watch.mjs --no-fail` | PASS | Advisory mode confirms watched dependencies are current. |
 | `node ./scripts/dependency-watch.mjs` | PASS | Strict mode confirms `tauri`, `tauri-utils`, `lancedb`, `lance`, and `lance-index` are current. |
@@ -35,6 +45,8 @@ Capture the current security/readiness state after the June 2026 audit, first de
 | `/tmp/knowledgecore-ui-deploy-codex-1781859269/node_modules/.bin/vitest run` | PASS | Exact lockfile deployed versions after linking missing `@rolldown/binding-darwin-arm64` from the repo pnpm virtual store into the temp deploy. |
 | `/tmp/knowledgecore-ui-deploy-codex-1781859269/node_modules/.bin/vite build --config vite.config.ts` | PASS | Exact lockfile deployed versions after the same temp-only native binding link. |
 | `/tmp/knowledgecore-ui-deploy-codex-1781859269/node_modules/.bin/tsc --noEmit --project tsconfig.json` | PASS | Exact lockfile deployed versions. |
+| `/tmp/knowledgecore-ui-deploy-state-1781862044/node_modules/.bin/tsc --noEmit --project tsconfig.json` | PASS | Fresh temp deploy from current source verifies the widened lock-status RPC type. |
+| `/tmp/knowledgecore-ui-deploy-state-1781862044/node_modules/.bin/vitest run` | PASS | Fresh temp deploy after temp-only `@rolldown/binding-darwin-arm64` link. |
 
 ## Hardening Applied
 - Desktop window now has a stable `main` label.
@@ -48,12 +60,19 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - UI lint, test, build, and typecheck gates passed from a temp deploy using lockfile package versions because repo-local `pnpm install` remains tool-policy blocked; `node_modules/.pnpm` content exists, but `apps/desktop/ui/node_modules` is still absent.
 - Non-migrating Ed25519 sync authorship verification helpers and tests were added behind the still-unwired `kc_core::sync_auth` module.
 - Recovery verification now decrypts `key_blob.enc` with the recovery phrase-derived key, checks the deterministic recovery nonce, rejects empty restored passphrases, and includes regressions for matching-hash forged blobs that cannot decrypt.
+- DB encryption lifecycle tests now pin unsupported mode/KDF rejection, idempotent already-encrypted migration detection, wrong-key failure for encrypted DB migration, and absence of stale `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
+- SQLCipher production state semantics are captured as an approval-gated design note in `docs/21-sqlcipher-state-model-plan-2026-06-19.md`; the documented decision is a future `vault.json` v4 `db_encryption.state` boundary, with no schema or runtime behavior changed in this lane.
+- SQLCipher status-only state derivation now reports v3/v4-equivalent states through core status, CLI DB-encryption JSON, and Tauri lock-status RPC without persisting `db_encryption.state` or rewriting vault files.
+- Recovery restore drill and resource guardrails are captured as an approval-gated implementation plan in `docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md`; the plan uses generated fixtures only and does not change runtime limits, vault formats, or cloud behavior.
+- Generated-fixture recovery restore drill tests now prove the recovery blob restores the vault passphrase and that the restored passphrase decrypts a generated encrypted object-store fixture; missing bundle-file coverage is pinned with `KC_RECOVERY_BUNDLE_INVALID`.
+- Opt-in resource-limit helpers and generated-fixture tests now cover ingest byte limits, sync snapshot zip archive/entry limits, PDF extraction input/output byte limits, and vector batch/text limits with `KC_RESOURCE_LIMIT_EXCEEDED`.
+- Approved production resource-limit defaults and first CLI/RPC wiring slice are captured in `docs/23-production-resource-limits-decision-2026-06-19.md`; CLI/RPC ingest, S3 sync pull zip extraction, and CLI index rebuild now pass default limits.
 
 ## Current Risk Posture
 - Critical: sync head v3 authorship is still not a cryptographic Ed25519 signature. The current implementation derives the author signature from public BLAKE3 inputs.
 - High: object-store KDF metadata still has a constant default salt id. Any per-vault random salt change requires explicit migration design approval.
-- High: SQLCipher enable/migrate lifecycle remains staged and needs a stronger state machine before broad production use.
-- Medium: recovery verification now proves core decrypt/restore behavior, but operator-level restore workflow coverage and recovery drill documentation still need to be finished.
+- High: SQLCipher enable/migrate lifecycle has status-only state derivation and a v4 explicit-state decision, but persisting `db_encryption.state` remains approval-gated.
+- Medium: recovery verification, generated-fixture restore drill coverage, opt-in resource-limit tests, and the first approved production resource-limit wiring slice are in place; PDF/OCR production wiring and filesystem snapshot directory size/count limits remain.
 - Medium: AWS recovery escrow code remains emulation-gated at runtime despite docs describing an AWS SDK backend.
 - Medium: OIDC/device identity flows remain local/simulated unless a real token/JWKS verification design is approved.
 - Medium: sync snapshot extraction, recursive ingest, PDF/OCR extraction, and vector persistence still need resource guardrails.
@@ -68,7 +87,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 
 ## Next Recommended Lane
 1. Decide key custody and schema transition for wiring Ed25519 signed sync heads into runtime acceptance.
-2. Add targeted tests or short design notes for DB encryption lifecycle states, operator-level recovery restore drills, and resource limits.
-3. Design-gate the remaining crypto work: per-vault random KDF salt migration and SQLCipher `pending/enabled/migrated` state semantics.
+2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
+3. Finish remaining approved resource-limit wiring for PDF/OCR production extraction and filesystem snapshot directory size/count enforcement.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.
 5. Restore repo-local UI dependencies in a non-blocked environment if local `pnpm lint`, `pnpm test`, and `pnpm -C apps/desktop/ui build` must be run exactly in place rather than from a temp deploy.

--- a/knowledgecore-docpack/docs/21-sqlcipher-state-model-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/21-sqlcipher-state-model-plan-2026-06-19.md
@@ -1,0 +1,104 @@
+# SQLCipher State Model Plan - 2026-06-19
+
+## Purpose
+Define the approval-gated state model needed before SQLCipher DB encryption is treated as production-ready across CLI, Tauri RPC, export/verifier, and operator recovery flows.
+
+This is a design note only. It does not change `vault.json`, database bytes, migration behavior, unlock behavior, or any runtime acceptance path.
+
+## Verified Current Behavior
+- `vault.json` v3 stores `db_encryption.enabled`, `mode`, `kdf.algorithm`, and `key_reference`.
+- New vaults default to `db_encryption.enabled = false`.
+- `vault_db_encrypt_enable_service` sets `enabled = true`, ensures `key_reference`, saves `vault.json`, and unlocks with the provided passphrase.
+- `vault_db_encrypt_migrate_service` requires `enabled = true`, calls `migrate_db_to_sqlcipher`, unlocks the DB, and appends a deterministic migration event.
+- `migrate_db_to_sqlcipher` returns `Migrated` for a plaintext source and `AlreadyEncrypted` only when the source no longer opens as plaintext and the supplied key validates.
+- Current tests pin unsupported mode/KDF rejection, valid unlock, wrong-key failure, idempotent already-encrypted detection, and cleanup of `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
+
+## Risk
+The current metadata has only a boolean `enabled`, while the operational lifecycle has multiple states. That is easy to misread:
+- `enabled = false` can mean DB encryption has never been requested.
+- `enabled = true` can mean encryption was requested but migration is not complete.
+- `enabled = true` can also mean the DB is already SQLCipher-encrypted and merely locked.
+
+This ambiguity is manageable for staged development, but not clean enough for production readiness, UI copy, verifier reporting, recovery drills, or support triage.
+
+## Proposed State Model
+Future runtime should represent DB encryption as an explicit state machine, not as a boolean-only interpretation.
+
+| State | Meaning | Allowed next actions | Hard failures |
+|---|---|---|---|
+| `disabled_plaintext` | DB encryption is not enabled and DB is expected to be plaintext. | `enable`, status, export/verify. | `migrate` without enable. |
+| `pending_migration` | Encryption metadata is configured but DB bytes are not yet proven SQLCipher-encrypted. | `migrate`, `disable_before_migrate` if explicitly designed, status, repair. | Treating the DB as production-encrypted. |
+| `migrated_locked` | DB bytes are SQLCipher-encrypted and no valid session/env passphrase is active. | `unlock`, status, export/verify metadata-only checks. | Opening DB contents without key. |
+| `migrated_unlocked` | DB bytes are SQLCipher-encrypted and passphrase/session validation succeeded. | normal DB access, `lock`, status. | Silent downgrade to plaintext. |
+| `migration_failed_recoverable` | Migration artifacts or rollback evidence require explicit repair/cleanup before proceeding. | `repair_status`, `repair_abort`, `repair_resume` if approved. | Continuing normal open/migrate without deterministic repair decision. |
+
+## Compatibility Decision
+Two implementation routes are plausible and require approval before code:
+
+1. Add `db_encryption.state` to `vault.json`.
+   - Likely cleaner for UI/RPC/status surfaces.
+   - Requires schema/registry updates, migration/read-compat rules, and fixture coverage.
+   - Needs a clear answer on whether this is an additive v3 field or a v4 schema boundary.
+
+2. Keep `vault.json` shape and infer state from metadata plus DB-byte inspection.
+   - Avoids schema change.
+   - Raises complexity and error-risk in every status/open path.
+   - Still requires deterministic tests for ambiguous states and artifact handling.
+
+Recommended design direction: introduce an explicit state field behind a schema/version decision, because operator-facing security state should be declarative and auditable.
+
+## Decision
+Use an explicit `db_encryption.state` field in a future `vault.json` v4 boundary.
+
+Rationale:
+- The state has security semantics, not just display metadata.
+- Treating `enabled = true` as both `pending_migration` and `migrated_*` is too ambiguous for production readiness.
+- A v4 boundary is cleaner than adding an optional v3 field whose absence would require every caller to infer safety-critical state.
+- Export/verifier, CLI, Tauri RPC, and UI can all report the same declarative state once the boundary is active.
+
+Compatibility contract for future implementation:
+- Existing v1/v2/v3 vaults remain readable during the transition.
+- v3 vaults with `db_encryption.enabled = false` map to `disabled_plaintext`.
+- v3 vaults with `db_encryption.enabled = true` must not be treated as production-encrypted until state derivation proves the DB bytes are SQLCipher-encrypted.
+- New v4 writes include `db_encryption.state`.
+- No v3-to-v4 rewrite happens implicitly on open.
+- Any v4 write path must update `SCHEMA_REGISTRY.md`, schema validation tests, export/verifier expectations, and CLI/RPC status tests.
+
+## Required Runtime Decisions
+- Enable may leave a vault in `pending_migration`; production readiness starts only after `migrated_locked` or `migrated_unlocked`.
+- Migration remains an explicit command; no automatic DB-byte migration on open.
+- Current plaintext DBs with `enabled = true` should surface as `pending_migration` or a migration-required error in future status/open logic, not as fully encrypted.
+- Failed migration artifacts should create a repair-required state and likely a new `KC_DB_ENCRYPTION_REPAIR_REQUIRED` error code.
+- Export/verifier reports should include explicit DB encryption state in addition to `enabled`.
+
+Still unresolved before runtime implementation:
+- Whether `pending_migration` can be explicitly disabled before DB-byte migration, and which audit event records that.
+- Exact repair commands and rollback UX for `migration_failed_recoverable`.
+
+## Safest First Implementation Slice
+After runtime implementation approval:
+1. Add state derivation tests for the five states without changing existing vault bytes. Done in the status-only checkpoint.
+2. Add a status-only helper that reports the inferred state and never opens decrypted contents unless a key is already valid. Done in the status-only checkpoint.
+3. Wire CLI/RPC status output to the helper. Done for core status, CLI DB-encryption JSON, and Tauri lock-status RPC in the status-only checkpoint.
+4. Add v4 schema/registry/tests and persist `db_encryption.state` only after the status-only helper is green. Still pending approval.
+
+## Status-Only Implementation Checkpoint
+- Added `DbEncryptionDerivedState` with string values matching the proposed state model.
+- Added `derive_db_encryption_state`, which reports state from v3 metadata, DB header inspection, unlock/session/env validation, and migration artifact presence.
+- Added coverage for `disabled_plaintext`, `pending_migration`, `migrated_locked`, `migrated_unlocked`, and `migration_failed_recoverable`.
+- Added `state` to core DB encryption status and lock status results.
+- Added `state` to CLI DB-encryption JSON output and Tauri lock-status RPC output.
+- This checkpoint does not persist `db_encryption.state`, rewrite `vault.json`, run a schema migration, or change DB migration behavior.
+
+## Stop Conditions
+- Any implementation that silently treats `pending_migration` as fully encrypted.
+- Any schema-affecting change without `SCHEMA_REGISTRY.md` and validation tests.
+- Any migration path that overwrites or deletes artifacts without deterministic repair/rollback evidence.
+- Any UI/RPC wording that implies production encryption before `migrated_locked` or `migrated_unlocked`.
+
+## Verification Expectations
+- `cargo test -p kc_core --test db_encryption`
+- `cargo test -p kc_core`
+- `cargo test --workspace --exclude apps_desktop_tauri`
+- `cargo test -p apps_desktop_tauri`
+- Export/verifier tests if state appears in manifests or reports.

--- a/knowledgecore-docpack/docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md
@@ -1,0 +1,52 @@
+# Recovery Drill and Resource Guardrails Plan - 2026-06-19
+
+## Purpose
+Define the next approval-safe implementation lane for recovery restore confidence and resource exhaustion controls without changing vault formats, weakening crypto, scanning private paths, or introducing background/cloud behavior.
+
+## Verified Current Inputs
+- Recovery bundle verification is local-only and now decrypts `key_blob.enc`, validates the deterministic nonce, and rejects undecryptable or empty restored passphrases.
+- Recovery bundle artifacts are documented in `spec/36-local-recovery-kit-v1.md`.
+- Scan-folder ingest is documented as lexicographic traversal in `spec/05-ingest-jobs-and-timestamp-resolution.md`.
+- PDF/OCR extraction is documented in `spec/04-canonical-text-v1-and-extractor-registry.md`.
+- Filesystem snapshot sync is documented in `spec/29-sync-v1-filesystem-snapshots.md`.
+- No private document ingest, real vault migration, or cloud sync operation was performed for this plan.
+
+## Recommended Implementation Slice
+This slice is implementation-ready after normal code-change approval because it avoids schema changes and does not require real user data.
+
+1. Done in this checkpoint: add deterministic recovery restore drill tests that generate temp fixture state, generate a local recovery bundle, verify it, restore the passphrase inside recovery module test scope, and prove the restored passphrase decrypts only the generated fixture object.
+2. Done in this checkpoint: add negative drill coverage for wrong phrase, tampered bundle, missing bundle files, and empty restored passphrase handling.
+3. Done in this checkpoint: add explicit opt-in resource-limit APIs and generated-fixture tests for ingest bytes, sync snapshot zip archive/entry limits, PDF input/extracted-text byte limits, and vector batch/text limits.
+4. Partially done in this checkpoint: approved defaults are wired into CLI/RPC ingest, S3 sync pull zip extraction, and CLI index rebuild. Remaining production wiring covers PDF/OCR extraction and filesystem snapshot directory size/count enforcement.
+
+## Guardrail Decisions Needed
+- Maximum single file size for ingest.
+- Maximum files per scan-folder request.
+- Maximum directory traversal depth and whether symlink following is disabled by default.
+- Maximum PDF pages and maximum OCR pages per document.
+- Maximum extracted canonical text bytes per document.
+- Maximum sync snapshot archive size and maximum extracted entries.
+- Maximum vector rows or batches accepted per rebuild/import operation.
+- Whether resource-limit violations should be retryable `AppError`s or hard policy failures.
+
+## Safety Constraints
+- Use only generated temp vaults and generated fixture files.
+- Do not scan broad local paths such as home, Documents, Desktop, Downloads, or repo parents.
+- Do not persist recovery phrases, vault passphrases, or decrypted key material in tracked files, logs, snapshots, or exported reports.
+- Do not alter recovery phrase derivation, SQLCipher parameters, Argon2 parameters, object-store encryption, or vault metadata.
+- Do not introduce cloud backup, background sync, or automatic upload behavior.
+- Do not enforce new production limits until default values and compatibility impact are approved.
+
+## Acceptance Criteria
+- Recovery drill tests prove that generate, verify, and restored-passphrase use are coherent on temp fixtures.
+- Recovery drill tests prove common failure cases return existing recovery `AppError` codes.
+- Resource-limit tests use generated fixture data and do not depend on private local documents.
+- Resource-limit behavior is deterministic for opt-in ingest, sync snapshot, PDF extraction, and vector persistence helpers.
+- Approved production defaults and first CLI/RPC wiring points are captured and partially enforced.
+- Documentation is updated with any approved defaults and stop conditions before production enforcement lands.
+
+## Approval Gates
+- Production resource-limit defaults require approval because they can reject previously accepted local files.
+- Any vault format, manifest, or schema change requires registry, fixture, migration, and rollback coverage.
+- Any recovery workflow that stores or transmits secret material requires explicit design review.
+- Any cloud escrow or sync behavior beyond existing explicitly configured surfaces requires explicit design approval.

--- a/knowledgecore-docpack/docs/23-production-resource-limits-decision-2026-06-19.md
+++ b/knowledgecore-docpack/docs/23-production-resource-limits-decision-2026-06-19.md
@@ -1,0 +1,69 @@
+# Production Resource Limits Decision - 2026-06-19
+
+## Purpose
+Define the approved production resource-limit defaults and wiring points for KnowledgeCore. The first enforcement slice is now wired at CLI/RPC boundaries using generated-fixture tests and without changing vault formats, migrations, cloud behavior, or private-data ingest.
+
+## Verified Current Inputs
+- Opt-in `KC_RESOURCE_LIMIT_EXCEEDED` helpers and generated-fixture tests exist for ingest bytes, sync snapshot zip archive/entry limits, PDF input/extracted-text byte limits, and vector batch/text limits.
+- CLI scan-folder and inbox ingest now pass approved defaults for byte, file-count, depth, and no-symlink-following behavior.
+- Tauri ingest RPC core service now passes approved defaults for scan-folder and inbox ingest.
+- S3 sync pull now passes approved zip archive/entry limits before snapshot extraction.
+- CLI index rebuild now passes approved vector row/text limits before LanceDB persistence.
+- PDF extraction has opt-in input/extracted-text byte guards, but the default extractor still uses unrestricted extraction.
+
+## Approved Defaults
+These values are intentionally conservative for a local-first desktop vault and should be adjusted only through explicit approval.
+
+| Surface | Proposed default | Rationale |
+|---|---:|---|
+| Ingest single file | 100 MiB | Prevents accidental huge binary ingest while allowing large PDFs/manuals. |
+| Scan-folder file count | 10,000 files | Bounds accidental broad-folder scans. |
+| Scan-folder traversal depth | 12 levels | Allows nested project folders while catching runaway trees. |
+| Symlink traversal | disabled | Avoids escaping selected roots and recursive link cycles. |
+| PDF input | 100 MiB | Matches single-file ingest ceiling. |
+| PDF extracted text | 25 MiB | Prevents extraction/OCR blowups before canonical persistence. |
+| OCR pages | 100 pages | Keeps OCR bounded; requires page-count plumbing before enforcement. |
+| Sync snapshot archive | 2 GiB | Allows realistic local vault snapshot movement while bounding decompression work. |
+| Sync snapshot entries | 250,000 entries | Bounds zip traversal and extraction loops. |
+| Sync snapshot entry | 250 MiB | Prevents single-entry extraction blowups. |
+| Vector rebuild rows per batch | 100,000 rows | Bounds LanceDB batch construction. |
+| Vector row text | 1 MiB | Prevents pathological chunk/canonical text rows entering vector persistence. |
+
+## Wiring State
+1. Done: single repo-owned defaults live in `kc_core::resource_limits`.
+2. Done: helper APIs remain opt-in internally, with defaults passed from selected production boundaries.
+3. Done: CLI ingest:
+   - `scan-folder`: enforces file size, file count, depth, and no symlink following.
+   - `inbox-once`: enforces single-file byte limit.
+4. Done: Tauri/core RPC ingest service:
+   - `ingest_scan_folder`: enforces the same scan-folder defaults.
+   - `ingest_inbox_start`: enforces single-file byte limit.
+5. Remaining: Extraction:
+   - add a limited `DefaultExtractor` construction path used by production indexing/ingest flows.
+   - retain unrestricted helpers for existing deterministic tests unless tests explicitly opt into limits.
+6. Partially done: Sync:
+   - S3 pull snapshot extraction routes through the existing opt-in zip limit helper.
+   - filesystem snapshot directories remain protected by existing top-level apply/path behavior but do not yet enforce size/count limits.
+   - keep path traversal rejection as a separate invariant.
+7. Done: Index:
+   - CLI index rebuild passes vector row/text limits before LanceDB persistence.
+8. UI:
+   - branch on `KC_RESOURCE_LIMIT_EXCEEDED` by code only and show the existing structured error path; do not add bespoke UI business logic.
+
+## Acceptance Tests
+- CLI scan-folder rejects generated temp trees over depth limits and does not ingest partial docs.
+- CLI inbox-once rejects generated oversized files before move/write.
+- Tauri/core RPC scan/inbox tests return `KC_RESOURCE_LIMIT_EXCEEDED` for generated oversized fixtures.
+- S3 sync pull rejects generated oversized archive/entry-count/entry-size fixtures before extraction writes.
+- Index rebuild rejects generated oversized vector batches/text rows before LanceDB writes.
+- Existing unrestricted unit helpers remain available for deterministic fixture tests.
+
+## Approval Gate
+Any further production limit expansion, default-value change, filesystem snapshot directory size/count enforcement, or PDF/OCR production wiring requires explicit approval because it changes accepted input behavior.
+
+## Stop Conditions
+- Any broad local path scan during testing.
+- Any private document ingest.
+- Any vault format or schema change.
+- Any cloud/background sync behavior change.
+- Any partial write after `KC_RESOURCE_LIMIT_EXCEEDED`.

--- a/knowledgecore-docpack/spec/04-canonical-text-v1-and-extractor-registry.md
+++ b/knowledgecore-docpack/spec/04-canonical-text-v1-and-extractor-registry.md
@@ -7,10 +7,12 @@ Defines canonical text normalization v1, marker formats, extraction provenance, 
 - Canonical text is UTF-8 and stored as an object; ground truth for all downstream operations.
 - Tier 1: marker lines included in canonical bytes/hashes.
 - Tier 2: PDF/OCR deterministic within pinned toolchain; tool changes define boundary.
+- PDF/OCR page, byte, and time/resource limits are policy boundaries; production default changes require explicit approval.
 
 ## Acceptance Tests
 - Golden tests validate marker insertion and normalization.
 - OCR triggers deterministically for scanned/no-text fixture; provenance recorded.
+- Resource-limit tests must use generated PDFs/images and must not ingest private documents.
 
 ## Normalization v1 (assumption)
 - Normalize line endings to `\n`.

--- a/knowledgecore-docpack/spec/05-ingest-jobs-and-timestamp-resolution.md
+++ b/knowledgecore-docpack/spec/05-ingest-jobs-and-timestamp-resolution.md
@@ -6,9 +6,11 @@ Defines scan-folder and inbox ingest jobs, deterministic processed-move, and sto
 ## Invariants
 - Tier 1: bytes-based identity; idempotent ingest.
 - effective_ts stored once at ingest; recency uses stored values only.
+- Resource limits for file size, file count, traversal depth, and symlink handling are policy boundaries; production default changes require explicit approval.
 
 ## Acceptance Tests
 - Tests validate traversal order, processed move naming, and timestamp resolution priority.
+- Resource-limit tests use generated fixture trees only and must not scan broad local paths or private document folders.
 
 ## Jobs
 - Scan-folder: traverse lexicographic full paths; ingest each file.

--- a/knowledgecore-docpack/spec/14-error-contract-app-error-taxonomy.md
+++ b/knowledgecore-docpack/spec/14-error-contract-app-error-taxonomy.md
@@ -53,6 +53,7 @@ AppError schema v1 and stable error taxonomy; UI branches on code only.
 - Schema validation: retryable=false
 - Tool unavailable (PDFium/Tesseract): retryable=true after install/config
 - Ask provider unavailable: retryable=true
+- Resource policy exceeded: retryable=false unless caller changes explicit limits or input.
 
 ## Taxonomy (v1)
 - Vault/DB: `KC_VAULT_*`, `KC_DB_*`
@@ -64,6 +65,7 @@ AppError schema v1 and stable error taxonomy; UI branches on code only.
 - Ingest: `KC_INGEST_*`, `KC_INBOX_*`, `KC_TIMESTAMP_*`
 - Extract: `KC_CANONICAL_*`, `KC_PDFIUM_UNAVAILABLE`, `KC_TESSERACT_UNAVAILABLE`, `KC_OCR_FAILED`
 - Chunking: `KC_CHUNK_*`
+- Resource policy: `KC_RESOURCE_LIMIT_EXCEEDED`
 - Index: `KC_FTS_*`, `KC_VECTOR_*`, `KC_EMBEDDING_*`
 - Retrieval: `KC_RETRIEVAL_*`
 - Locator/Snippet: `KC_LOCATOR_*`, `KC_SNIPPET_*`

--- a/knowledgecore-docpack/spec/29-sync-v1-filesystem-snapshots.md
+++ b/knowledgecore-docpack/spec/29-sync-v1-filesystem-snapshots.md
@@ -8,6 +8,7 @@ Define deterministic push/pull synchronization against a filesystem target using
 - Snapshot ids are deterministic hashes derived from manifest hash + `now_ms`.
 - Conflict handling never auto-merges; it emits a deterministic conflict artifact and fails.
 - Pull applies only top-level snapshot data trees (`db`, `store`, `index`) and never mutates `vault.json`.
+- Snapshot archive size, extracted entry count, and extraction path validation are resource and safety boundaries; production default changes require explicit approval.
 
 ## Non-goals
 - Bidirectional merge strategies.
@@ -38,6 +39,7 @@ Define deterministic push/pull synchronization against a filesystem target using
 - Clean push writes head + snapshot and updates local sync state.
 - Clean pull applies remote snapshot content to local vault.
 - Divergence emits deterministic conflict artifact and hard-fails.
+- Oversized or path-unsafe snapshot fixtures fail deterministically without writing outside the temp vault.
 - RPC and CLI contract tests pass.
 
 ## Rollout gate

--- a/knowledgecore-docpack/spec/32-sqlite-encryption-sqlcipher-v1.md
+++ b/knowledgecore-docpack/spec/32-sqlite-encryption-sqlcipher-v1.md
@@ -3,11 +3,16 @@
 ## Purpose
 Define DB-at-rest encryption contracts using SQLCipher with vault schema v3 and explicit unlock/migration flows.
 
+See `docs/21-sqlcipher-state-model-plan-2026-06-19.md` for the approval-gated production state model plan. That plan chooses a future `vault.json` v4 `db_encryption.state` boundary, but it is not active runtime behavior until implementation approval, registry updates, schema validation tests, and compatibility coverage land.
+
 ## Invariants
 - Object-store encryption behavior from v2 remains valid and optional.
 - SQLCipher DB encryption is opt-in and versioned.
 - `vault_open` supports v1/v2/v3 and normalizes to active internal model.
 - Unlock/lock/session behavior is explicit and reported via `AppError.code`.
+- Unsupported DB encryption mode or KDF metadata hard-fails before unlock or migration proceeds.
+- Migration is idempotent for an already encrypted DB when the supplied passphrase validates.
+- Status surfaces may report an inferred SQLCipher lifecycle state for v3 vaults; this is status-only until the v4 state boundary is implemented.
 
 ## Non-goals
 - External KMS integration.
@@ -43,9 +48,13 @@ Define DB-at-rest encryption contracts using SQLCipher with vault schema v3 and 
 
 ## Acceptance tests
 - v1/v2 vaults open and normalize; v3 vault opens with expected DB metadata.
+- Unsupported DB encryption mode and unsupported DB KDF algorithm fail with `KC_DB_ENCRYPTION_UNSUPPORTED`.
 - Encrypted DB unlock with valid passphrase succeeds.
 - Invalid passphrase fails with `KC_DB_KEY_INVALID`.
 - Migration integrity check passes and no active plaintext DB remains.
+- Re-running migration on an already encrypted DB returns `already_encrypted` for the valid key and `KC_DB_KEY_INVALID` for a wrong key.
+- Successful migration leaves no `.sqlcipher.tmp` or `.pre-sqlcipher.bak` artifact.
+- Status-only state derivation covers `disabled_plaintext`, `pending_migration`, `migrated_locked`, `migrated_unlocked`, and `migration_failed_recoverable`.
 - Export/verifier schema checks include DB encryption metadata.
 
 ## Rollout gate and stop conditions

--- a/knowledgecore-docpack/spec/36-local-recovery-kit-v1.md
+++ b/knowledgecore-docpack/spec/36-local-recovery-kit-v1.md
@@ -58,6 +58,7 @@ Define local-only recovery bundle contracts for restoring vault encryption acces
 - Verify succeeds with correct phrase and fails with `KC_RECOVERY_PHRASE_INVALID` on mismatch.
 - Tampered bundle fails with `KC_RECOVERY_BUNDLE_INVALID`.
 - Matching-hash forged blobs that cannot decrypt, or whose nonce no longer matches the manifest context, fail with `KC_RECOVERY_BUNDLE_INVALID`.
+- Operator restore drill tests must use generated temp vaults only and prove the restored passphrase can unlock/decrypt the generated fixture without persisting secret material.
 - Recovery schema validation tests pass.
 
 ## Rollout gate and stop conditions


### PR DESCRIPTION
## What

Adds the next KnowledgeCore security-readiness guardrail slice:

- DB encryption derived state reporting for status-only surfaces (`disabled_plaintext`, `pending_migration`, `migrated_locked`, `migrated_unlocked`, `migration_failed_recoverable`).
- CLI/RPC/Tauri lock-status propagation for the derived DB encryption state.
- Recovery restore drill coverage proving a generated recovery bundle can restore the passphrase and decrypt a generated encrypted object-store fixture.
- Resource-limit defaults and first production wiring for CLI/RPC ingest, S3 sync snapshot extraction, and CLI index rebuild.
- Generated-fixture tests for ingest, sync zip extraction, PDF extraction, vector persistence, and scan-folder depth rejection.
- Docpack updates for the SQLCipher state model, recovery/resource guardrail plan, production resource-limit decision, and current readiness checkpoint.

## Why

The repo had strong staged security primitives, but several operator-facing readiness gaps remained: ambiguous SQLCipher lifecycle status, recovery restore confidence, and resource exhaustion boundaries. This slice improves those surfaces without changing vault formats, weakening crypto, introducing background/cloud behavior, or scanning private local data.

## How

- Keeps SQLCipher state persistence approval-gated while deriving status from v3 metadata, DB header/artifact inspection, and unlock validation.
- Uses generated temp fixtures for all new recovery and resource-limit tests.
- Adds repo-owned resource-limit defaults in `kc_core::resource_limits`.
- Wires the approved first production limit slice only at selected CLI/RPC boundaries.
- Leaves PDF/OCR production enforcement and filesystem snapshot directory size/count enforcement as the next lane.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated

Verification run locally:

- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm audit:rust`
- `pnpm lint`
- `pnpm test`
- `pnpm -C apps/desktop/ui typecheck && pnpm -C apps/desktop/ui build`
