### PR TITLE
feat: complete resource limit wiring

### DIFF
--- a/crates/kc_core/src/resource_limits.rs
+++ b/crates/kc_core/src/resource_limits.rs
@@ -8,6 +8,7 @@ pub const SCAN_FOLDER_MAX_FILES: usize = 10_000;
 pub const SCAN_FOLDER_MAX_DEPTH: usize = 12;
 pub const PDF_INPUT_MAX_BYTES: usize = 100 * MIB;
 pub const PDF_EXTRACTED_TEXT_MAX_BYTES: usize = 25 * MIB;
+pub const OCR_MAX_PAGES: usize = 100;
 pub const SYNC_SNAPSHOT_MAX_ARCHIVE_BYTES: usize = 2 * 1024 * MIB;
 pub const SYNC_SNAPSHOT_MAX_ENTRIES: usize = 250_000;
 pub const SYNC_SNAPSHOT_MAX_ENTRY_BYTES: u64 = (250 * MIB) as u64;

--- a/crates/kc_core/src/sync.rs
+++ b/crates/kc_core/src/sync.rs
@@ -846,6 +846,7 @@ fn should_conflict(
 }
 
 fn apply_snapshot_to_vault(snapshot_dir: &Path, vault_path: &Path) -> AppResult<()> {
+    validate_snapshot_dir_limits(snapshot_dir, sync_snapshot_limits())?;
     for top in ["db", "store", "index"] {
         let src = snapshot_dir.join(top);
         if !src.exists() {
@@ -880,6 +881,69 @@ fn apply_snapshot_to_vault(snapshot_dir: &Path, vault_path: &Path) -> AppResult<
         })?;
         copy_tree_sorted(&src, &dst)?;
     }
+    Ok(())
+}
+
+fn validate_snapshot_dir_limits(
+    snapshot_dir: &Path,
+    limits: SyncSnapshotResourceLimits,
+) -> AppResult<()> {
+    let mut files = Vec::new();
+    for top in ["db", "store", "index"] {
+        let src = snapshot_dir.join(top);
+        if !src.exists() {
+            continue;
+        }
+        if src.is_file() {
+            files.push(src);
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&src)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+        {
+            files.push(entry.path().to_path_buf());
+        }
+    }
+    files.sort();
+
+    if files.len() > limits.max_entries {
+        return Err(sync_error(
+            "KC_RESOURCE_LIMIT_EXCEEDED",
+            "sync snapshot directory exceeds configured entry limit",
+            serde_json::json!({
+                "entries": files.len(),
+                "max_entries": limits.max_entries,
+                "path": snapshot_dir,
+            }),
+        ));
+    }
+
+    for file in files {
+        let len = fs::metadata(&file)
+            .map_err(|e| {
+                sync_error(
+                    "KC_SYNC_TARGET_INVALID",
+                    "failed reading sync snapshot file metadata",
+                    serde_json::json!({ "error": e.to_string(), "path": file }),
+                )
+            })?
+            .len();
+        if len > limits.max_entry_bytes {
+            return Err(sync_error(
+                "KC_RESOURCE_LIMIT_EXCEEDED",
+                "sync snapshot directory entry exceeds configured byte limit",
+                serde_json::json!({
+                    "path": file,
+                    "bytes": len,
+                    "max_entry_bytes": limits.max_entry_bytes,
+                }),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -2145,7 +2209,10 @@ pub fn sync_pull_target_with_mode(
 
 #[cfg(test)]
 mod tests {
-    use super::{unpack_zip_snapshot, unpack_zip_snapshot_with_limits, SyncSnapshotResourceLimits};
+    use super::{
+        unpack_zip_snapshot, unpack_zip_snapshot_with_limits, validate_snapshot_dir_limits,
+        SyncSnapshotResourceLimits,
+    };
     use std::io::Write;
     use zip::write::SimpleFileOptions;
 
@@ -2234,5 +2301,30 @@ mod tests {
         assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
         assert!(!out.join("manifest.json").exists());
         assert!(!out.join("db/knowledge.sqlite").exists());
+    }
+
+    #[test]
+    fn snapshot_dir_limits_reject_generated_oversized_entry_before_apply() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let snapshot = root.path().join("snapshot");
+        let db_dir = snapshot.join("db");
+        std::fs::create_dir_all(&db_dir).expect("create snapshot db dir");
+        std::fs::write(
+            db_dir.join("knowledge.sqlite"),
+            b"generated oversized db fixture",
+        )
+        .expect("write generated fixture");
+
+        let err = validate_snapshot_dir_limits(
+            &snapshot,
+            SyncSnapshotResourceLimits {
+                max_archive_bytes: 1024,
+                max_entries: 8,
+                max_entry_bytes: 8,
+            },
+        )
+        .expect_err("oversized snapshot dir entry should fail");
+
+        assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
     }
 }

--- a/crates/kc_extract/src/extractor.rs
+++ b/crates/kc_extract/src/extractor.rs
@@ -2,12 +2,14 @@ use crate::html::canonicalize_html;
 use crate::md::canonicalize_markdown;
 use crate::normalize::normalize_text_v1;
 use crate::ocr::{
-    ocr_pdf_via_images, should_run_ocr, tesseract_version, traineddata_hashes, OcrConfig,
+    ocr_pdf_via_images_with_limits, should_run_ocr, tesseract_version, traineddata_hashes,
+    OcrConfig, OcrResourceLimits,
 };
-use crate::pdf::{extract_pdf_text, PdfiumConfig};
+use crate::pdf::{extract_pdf_text_with_limits, PdfResourceLimits, PdfiumConfig};
 use kc_core::app_error::{AppError, AppResult};
 use kc_core::canon_json::to_canonical_bytes;
 use kc_core::hashing::blake3_hex_prefixed;
+use kc_core::resource_limits::{OCR_MAX_PAGES, PDF_EXTRACTED_TEXT_MAX_BYTES, PDF_INPUT_MAX_BYTES};
 use kc_core::services::{CanonicalTextArtifact, ExtractInput, ExtractService, ToolchainIdentity};
 use kc_core::types::{CanonicalHash, ObjectHash};
 
@@ -52,14 +54,24 @@ impl ExtractService for DefaultExtractor {
                 canonicalize_html(&text)
             }
             "application/pdf" => {
-                let pdf = extract_pdf_text(input.bytes, &PdfiumConfig { library_path: None })?;
+                let pdf = extract_pdf_text_with_limits(
+                    input.bytes,
+                    &PdfiumConfig { library_path: None },
+                    Some(PdfResourceLimits {
+                        max_input_bytes: PDF_INPUT_MAX_BYTES,
+                        max_extracted_bytes: PDF_EXTRACTED_TEXT_MAX_BYTES,
+                    }),
+                )?;
                 if should_run_ocr(pdf.extracted_len, pdf.extracted_alnum_ratio) {
-                    match ocr_pdf_via_images(
+                    match ocr_pdf_via_images_with_limits(
                         input.bytes,
                         &OcrConfig {
                             tesseract_cmd: None,
                             language: ocr_language.clone(),
                         },
+                        Some(OcrResourceLimits {
+                            max_pages: OCR_MAX_PAGES,
+                        }),
                     ) {
                         Ok(ocr_text) => {
                             ocr_used = true;

--- a/crates/kc_extract/src/ocr.rs
+++ b/crates/kc_extract/src/ocr.rs
@@ -10,8 +10,29 @@ pub struct OcrConfig {
     pub language: String,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct OcrResourceLimits {
+    pub max_pages: usize,
+}
+
 pub fn should_run_ocr(extracted_len: usize, alnum_ratio: f64) -> bool {
     extracted_len < 800 || alnum_ratio < 0.10
+}
+
+pub fn validate_ocr_page_count(page_count: usize, limits: OcrResourceLimits) -> AppResult<()> {
+    if page_count > limits.max_pages {
+        return Err(AppError::new(
+            "KC_RESOURCE_LIMIT_EXCEEDED",
+            "extract",
+            "ocr page count exceeds configured limit",
+            false,
+            serde_json::json!({
+                "pages": page_count,
+                "max_pages": limits.max_pages,
+            }),
+        ));
+    }
+    Ok(())
 }
 
 pub fn tesseract_version(tesseract_cmd: &str) -> AppResult<String> {
@@ -72,8 +93,23 @@ pub fn traineddata_hashes(language: &str) -> Vec<String> {
 }
 
 pub fn ocr_pdf_via_images(pdf_bytes: &[u8], ocr_cfg: &OcrConfig) -> AppResult<String> {
+    ocr_pdf_via_images_with_limits(pdf_bytes, ocr_cfg, None)
+}
+
+pub fn ocr_pdf_via_images_with_limits(
+    pdf_bytes: &[u8],
+    ocr_cfg: &OcrConfig,
+    limits: Option<OcrResourceLimits>,
+) -> AppResult<String> {
     if let Ok(fake) = std::env::var("KC_OCR_FAKE_TEXT") {
         if !fake.is_empty() {
+            if let (Some(limits), Ok(fake_pages)) =
+                (limits, std::env::var("KC_OCR_FAKE_PAGE_COUNT"))
+            {
+                if let Ok(fake_pages) = fake_pages.parse::<usize>() {
+                    validate_ocr_page_count(fake_pages, limits)?;
+                }
+            }
             return Ok(fake);
         }
     }
@@ -149,6 +185,9 @@ pub fn ocr_pdf_via_images(pdf_bytes: &[u8], ocr_cfg: &OcrConfig) -> AppResult<St
         .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("png"))
         .collect();
     pages.sort();
+    if let Some(limits) = limits {
+        validate_ocr_page_count(pages.len(), limits)?;
+    }
 
     let mut text = String::new();
     for (idx, page) in pages.into_iter().enumerate() {

--- a/crates/kc_extract/tests/golden_pdf.rs
+++ b/crates/kc_extract/tests/golden_pdf.rs
@@ -1,6 +1,8 @@
 use kc_core::services::{ExtractInput, ExtractService, ToolchainIdentity};
 use kc_core::types::DocId;
-use kc_extract::ocr::{ocr_pdf_via_images, should_run_ocr, OcrConfig};
+use kc_extract::ocr::{
+    ocr_pdf_via_images, should_run_ocr, validate_ocr_page_count, OcrConfig, OcrResourceLimits,
+};
 use kc_extract::pdf::{
     extract_pdf_text, extract_pdf_text_with_limits, PdfResourceLimits, PdfiumConfig,
 };
@@ -105,6 +107,14 @@ fn pdf_resource_limits_reject_generated_oversized_extracted_text() {
         }),
     )
     .expect_err("oversized generated extracted text should fail");
+
+    assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+}
+
+#[test]
+fn ocr_resource_limits_reject_generated_oversized_page_count() {
+    let err = validate_ocr_page_count(101, OcrResourceLimits { max_pages: 100 })
+        .expect_err("oversized generated page count should fail");
 
     assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
 }

--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -66,16 +66,16 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Recovery restore drill and resource guardrails are captured as an approval-gated implementation plan in `docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md`; the plan uses generated fixtures only and does not change runtime limits, vault formats, or cloud behavior.
 - Generated-fixture recovery restore drill tests now prove the recovery blob restores the vault passphrase and that the restored passphrase decrypts a generated encrypted object-store fixture; missing bundle-file coverage is pinned with `KC_RECOVERY_BUNDLE_INVALID`.
 - Opt-in resource-limit helpers and generated-fixture tests now cover ingest byte limits, sync snapshot zip archive/entry limits, PDF extraction input/output byte limits, and vector batch/text limits with `KC_RESOURCE_LIMIT_EXCEEDED`.
-- Approved production resource-limit defaults and first CLI/RPC wiring slice are captured in `docs/23-production-resource-limits-decision-2026-06-19.md`; CLI/RPC ingest, S3 sync pull zip extraction, and CLI index rebuild now pass default limits.
+- Approved production resource-limit defaults and wiring slices are captured in `docs/23-production-resource-limits-decision-2026-06-19.md`; CLI/RPC ingest, default PDF byte extraction, OCR page-count validation, S3 sync pull zip extraction, filesystem snapshot directory apply preflight, and CLI index rebuild now pass default limits.
 
 ## Current Risk Posture
 - Critical: sync head v3 authorship is still not a cryptographic Ed25519 signature. The current implementation derives the author signature from public BLAKE3 inputs.
 - High: object-store KDF metadata still has a constant default salt id. Any per-vault random salt change requires explicit migration design approval.
 - High: SQLCipher enable/migrate lifecycle has status-only state derivation and a v4 explicit-state decision, but persisting `db_encryption.state` remains approval-gated.
-- Medium: recovery verification, generated-fixture restore drill coverage, opt-in resource-limit tests, and the first approved production resource-limit wiring slice are in place; PDF/OCR production wiring and filesystem snapshot directory size/count limits remain.
+- Medium: recovery verification, generated-fixture restore drill coverage, opt-in resource-limit tests, and approved production resource-limit wiring slices are in place; future resource-limit work should focus on compatibility tuning and any newly approved surfaces.
 - Medium: AWS recovery escrow code remains emulation-gated at runtime despite docs describing an AWS SDK backend.
 - Medium: OIDC/device identity flows remain local/simulated unless a real token/JWKS verification design is approved.
-- Medium: sync snapshot extraction, recursive ingest, PDF/OCR extraction, and vector persistence still need resource guardrails.
+- Medium: PDF/OCR extraction now has byte and OCR page-count guardrails; maximum page limits for non-OCR PDF text extraction remain a future design decision if needed.
 - Medium: RustSec still reports 16 reviewed informational warnings, mostly GTK3/Tauri Linux backend transitives plus macro/unicode transitives; they are policy-gated for review by `2026-07-19`.
 
 ## Approval Gates
@@ -88,6 +88,6 @@ Capture the current security/readiness state after the June 2026 audit, first de
 ## Next Recommended Lane
 1. Decide key custody and schema transition for wiring Ed25519 signed sync heads into runtime acceptance.
 2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
-3. Finish remaining approved resource-limit wiring for PDF/OCR production extraction and filesystem snapshot directory size/count enforcement.
+3. Decide whether non-OCR PDF page-count limits are needed beyond the current PDF byte and OCR page-count guardrails.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.
 5. Restore repo-local UI dependencies in a non-blocked environment if local `pnpm lint`, `pnpm test`, and `pnpm -C apps/desktop/ui build` must be run exactly in place rather than from a temp deploy.

--- a/knowledgecore-docpack/docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/22-recovery-drill-and-resource-guardrails-plan-2026-06-19.md
@@ -17,13 +17,13 @@ This slice is implementation-ready after normal code-change approval because it 
 1. Done in this checkpoint: add deterministic recovery restore drill tests that generate temp fixture state, generate a local recovery bundle, verify it, restore the passphrase inside recovery module test scope, and prove the restored passphrase decrypts only the generated fixture object.
 2. Done in this checkpoint: add negative drill coverage for wrong phrase, tampered bundle, missing bundle files, and empty restored passphrase handling.
 3. Done in this checkpoint: add explicit opt-in resource-limit APIs and generated-fixture tests for ingest bytes, sync snapshot zip archive/entry limits, PDF input/extracted-text byte limits, and vector batch/text limits.
-4. Partially done in this checkpoint: approved defaults are wired into CLI/RPC ingest, S3 sync pull zip extraction, and CLI index rebuild. Remaining production wiring covers PDF/OCR extraction and filesystem snapshot directory size/count enforcement.
+4. Done in this checkpoint: approved defaults are wired into CLI/RPC ingest, default PDF byte extraction, OCR page-count validation before Tesseract OCR, S3 sync pull zip extraction, filesystem snapshot directory apply preflight, and CLI index rebuild.
 
 ## Guardrail Decisions Needed
 - Maximum single file size for ingest.
 - Maximum files per scan-folder request.
 - Maximum directory traversal depth and whether symlink following is disabled by default.
-- Maximum PDF pages and maximum OCR pages per document.
+- Maximum OCR pages per document is approved and wired; maximum PDF pages for non-OCR extraction remains a future decision if needed.
 - Maximum extracted canonical text bytes per document.
 - Maximum sync snapshot archive size and maximum extracted entries.
 - Maximum vector rows or batches accepted per rebuild/import operation.
@@ -42,7 +42,7 @@ This slice is implementation-ready after normal code-change approval because it 
 - Recovery drill tests prove common failure cases return existing recovery `AppError` codes.
 - Resource-limit tests use generated fixture data and do not depend on private local documents.
 - Resource-limit behavior is deterministic for opt-in ingest, sync snapshot, PDF extraction, and vector persistence helpers.
-- Approved production defaults and first CLI/RPC wiring points are captured and partially enforced.
+- Approved production defaults and current CLI/RPC/extract/sync/index wiring points are captured and partially enforced.
 - Documentation is updated with any approved defaults and stop conditions before production enforcement lands.
 
 ## Approval Gates

--- a/knowledgecore-docpack/docs/23-production-resource-limits-decision-2026-06-19.md
+++ b/knowledgecore-docpack/docs/23-production-resource-limits-decision-2026-06-19.md
@@ -4,12 +4,14 @@
 Define the approved production resource-limit defaults and wiring points for KnowledgeCore. The first enforcement slice is now wired at CLI/RPC boundaries using generated-fixture tests and without changing vault formats, migrations, cloud behavior, or private-data ingest.
 
 ## Verified Current Inputs
-- Opt-in `KC_RESOURCE_LIMIT_EXCEEDED` helpers and generated-fixture tests exist for ingest bytes, sync snapshot zip archive/entry limits, PDF input/extracted-text byte limits, and vector batch/text limits.
+- Opt-in `KC_RESOURCE_LIMIT_EXCEEDED` helpers and generated-fixture tests exist for ingest bytes, sync snapshot zip archive/entry limits, PDF input/extracted-text byte limits, OCR page-count limits, and vector batch/text limits.
 - CLI scan-folder and inbox ingest now pass approved defaults for byte, file-count, depth, and no-symlink-following behavior.
 - Tauri ingest RPC core service now passes approved defaults for scan-folder and inbox ingest.
 - S3 sync pull now passes approved zip archive/entry limits before snapshot extraction.
 - CLI index rebuild now passes approved vector row/text limits before LanceDB persistence.
-- PDF extraction has opt-in input/extracted-text byte guards, but the default extractor still uses unrestricted extraction.
+- Default PDF extraction now passes approved input/extracted-text byte guards before canonical persistence.
+- Default OCR extraction now passes approved page-count guards after PDF-to-image rendering and before Tesseract OCR.
+- Filesystem snapshot directory apply now preflights approved entry-count and per-entry byte limits before replacing vault paths.
 
 ## Approved Defaults
 These values are intentionally conservative for a local-first desktop vault and should be adjusted only through explicit approval.
@@ -22,7 +24,7 @@ These values are intentionally conservative for a local-first desktop vault and 
 | Symlink traversal | disabled | Avoids escaping selected roots and recursive link cycles. |
 | PDF input | 100 MiB | Matches single-file ingest ceiling. |
 | PDF extracted text | 25 MiB | Prevents extraction/OCR blowups before canonical persistence. |
-| OCR pages | 100 pages | Keeps OCR bounded; requires page-count plumbing before enforcement. |
+| OCR pages | 100 pages | Keeps OCR bounded before Tesseract page processing. |
 | Sync snapshot archive | 2 GiB | Allows realistic local vault snapshot movement while bounding decompression work. |
 | Sync snapshot entries | 250,000 entries | Bounds zip traversal and extraction loops. |
 | Sync snapshot entry | 250 MiB | Prevents single-entry extraction blowups. |
@@ -38,12 +40,13 @@ These values are intentionally conservative for a local-first desktop vault and 
 4. Done: Tauri/core RPC ingest service:
    - `ingest_scan_folder`: enforces the same scan-folder defaults.
    - `ingest_inbox_start`: enforces single-file byte limit.
-5. Remaining: Extraction:
-   - add a limited `DefaultExtractor` construction path used by production indexing/ingest flows.
+5. Done: Extraction:
+   - `DefaultExtractor` now enforces approved PDF input and extracted-text byte limits.
+   - `DefaultExtractor` now enforces approved OCR page-count limits after PDF-to-image rendering and before Tesseract OCR.
    - retain unrestricted helpers for existing deterministic tests unless tests explicitly opt into limits.
-6. Partially done: Sync:
+6. Done: Sync:
    - S3 pull snapshot extraction routes through the existing opt-in zip limit helper.
-   - filesystem snapshot directories remain protected by existing top-level apply/path behavior but do not yet enforce size/count limits.
+   - filesystem snapshot directory apply preflights entry-count and per-entry byte limits before replacing vault paths.
    - keep path traversal rejection as a separate invariant.
 7. Done: Index:
    - CLI index rebuild passes vector row/text limits before LanceDB persistence.
@@ -55,11 +58,13 @@ These values are intentionally conservative for a local-first desktop vault and 
 - CLI inbox-once rejects generated oversized files before move/write.
 - Tauri/core RPC scan/inbox tests return `KC_RESOURCE_LIMIT_EXCEEDED` for generated oversized fixtures.
 - S3 sync pull rejects generated oversized archive/entry-count/entry-size fixtures before extraction writes.
+- Filesystem snapshot directory preflight rejects generated oversized entries before vault apply writes.
+- OCR page-count validation rejects generated oversized page counts before Tesseract OCR.
 - Index rebuild rejects generated oversized vector batches/text rows before LanceDB writes.
 - Existing unrestricted unit helpers remain available for deterministic fixture tests.
 
 ## Approval Gate
-Any further production limit expansion, default-value change, filesystem snapshot directory size/count enforcement, or PDF/OCR production wiring requires explicit approval because it changes accepted input behavior.
+Any further production limit expansion or default-value change requires explicit approval because it changes accepted input behavior.
 
 ## Stop Conditions
 - Any broad local path scan during testing.


### PR DESCRIPTION
## What

Completes the approved resource-limit wiring slice after #147:

- Enforces approved PDF input/extracted-text byte defaults in `DefaultExtractor`.
- Adds OCR page-count limit validation and wires it before Tesseract OCR work.
- Adds filesystem snapshot directory entry-count/per-entry-size preflight before vault apply.
- Updates resource-limit docs/checkpoint to reflect the completed wiring and remaining future decision around non-OCR PDF page limits.

## Why

#147 landed the security readiness base and first production resource-limit boundaries. This follow-up closes the remaining approved resource-limit surfaces without changing vault formats, migrations, cloud behavior, or private-data ingest.

## How

- Uses the repo-owned defaults in `kc_core::resource_limits`.
- Keeps unrestricted helper paths available for deterministic tests.
- Uses generated-fixture tests only.
- Preserves existing sync path traversal checks as separate invariants.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated

Verification run locally:

- `cargo fmt --all --check`
- `cargo test -p kc_extract ocr_resource_limits`
- `cargo test -p kc_extract pdf_resource_limits`
- `cargo test -p kc_core snapshot_dir_limits`
- `cargo clippy --workspace --all-targets -- -D warnings`
