### PR TITLE
feat: add sync head Ed25519 verification bridge

### DIFF
--- a/crates/kc_core/src/sync.rs
+++ b/crates/kc_core/src/sync.rs
@@ -4,6 +4,7 @@ use crate::db::open_db;
 use crate::export::{export_bundle, ExportOptions};
 use crate::hashing::blake3_hex_prefixed;
 use crate::resource_limits::sync_snapshot_limits;
+use crate::sync_auth::verify_sync_head_author_signature_v1;
 use crate::sync_merge::{
     ensure_conservative_merge_safe, ensure_conservative_plus_v2_merge_safe,
     ensure_conservative_plus_v3_merge_safe, ensure_conservative_plus_v4_merge_safe,
@@ -12,8 +13,10 @@ use crate::sync_merge::{
 };
 use crate::sync_s3::S3SyncTransport;
 use crate::sync_transport::{FsSyncTransport, SyncTargetUri, SyncTransport};
+use crate::trust;
 use crate::trust_identity;
 use crate::vault::{vault_open, VaultJsonV2};
+use ed25519_dalek::{Signer, SigningKey};
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -1019,7 +1022,7 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
     out
 }
 
-fn sign_sync_payload(payload: &[u8]) -> String {
+fn legacy_sync_signature(payload: &[u8]) -> String {
     let h1 = blake3::hash(payload);
     let mut second_seed = Vec::with_capacity(16 + payload.len());
     second_seed.extend_from_slice(b"kc.sync.sig.v1\n");
@@ -1029,6 +1032,82 @@ fn sign_sync_payload(payload: &[u8]) -> String {
     sig.push_str(&bytes_to_hex(h1.as_bytes()));
     sig.push_str(&bytes_to_hex(h2.as_bytes()));
     sig
+}
+
+fn parse_lower_hex_fixed<const N: usize>(
+    value: &str,
+    field: &str,
+    code: &str,
+) -> AppResult<[u8; N]> {
+    if value.len() != N * 2
+        || !value
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        return Err(sync_error(
+            code,
+            "hex value has invalid shape",
+            serde_json::json!({
+                "field": field,
+                "expected_hex_chars": N * 2,
+                "actual_hex_chars": value.len()
+            }),
+        ));
+    }
+
+    let mut out = [0u8; N];
+    for (idx, slot) in out.iter_mut().enumerate() {
+        let start = idx * 2;
+        *slot = u8::from_str_radix(&value[start..start + 2], 16).map_err(|e| {
+            sync_error(
+                code,
+                "hex value contains invalid byte",
+                serde_json::json!({
+                    "field": field,
+                    "index": idx,
+                    "error": e.to_string()
+                }),
+            )
+        })?;
+    }
+    Ok(out)
+}
+
+fn sign_sync_payload(
+    conn: &Connection,
+    author_device_id: &str,
+    payload: &[u8],
+) -> AppResult<String> {
+    let Ok(seed_hex) = std::env::var("KC_SYNC_AUTHOR_SIGNING_KEY_HEX") else {
+        return Ok(legacy_sync_signature(payload));
+    };
+    let seed = parse_lower_hex_fixed::<32>(
+        seed_hex.trim(),
+        "KC_SYNC_AUTHOR_SIGNING_KEY_HEX",
+        "KC_SYNC_AUTH_FAILED",
+    )?;
+    let signing_key = SigningKey::from_bytes(&seed);
+    let expected_pubkey =
+        trust::trusted_device_public_key(conn, author_device_id).map_err(|e| {
+            sync_error(
+                "KC_SYNC_AUTH_FAILED",
+                "failed resolving trusted device key for sync signing",
+                serde_json::json!({
+                    "source_code": e.code,
+                    "source_message": e.message,
+                    "author_device_id": author_device_id
+                }),
+            )
+        })?;
+    let actual_pubkey = bytes_to_hex(&signing_key.verifying_key().to_bytes());
+    if actual_pubkey != expected_pubkey {
+        return Err(sync_error(
+            "KC_SYNC_AUTH_FAILED",
+            "sync signing key does not match trusted author device",
+            serde_json::json!({ "author_device_id": author_device_id }),
+        ));
+    }
+    Ok(bytes_to_hex(&signing_key.sign(payload).to_bytes()))
 }
 
 #[derive(Debug, Clone)]
@@ -1064,7 +1143,7 @@ fn local_sync_author(conn: &Connection) -> AppResult<SyncAuthorV3> {
 }
 
 fn ensure_remote_trust_matches(
-    _conn: &Connection,
+    conn: &Connection,
     remote_head: Option<&SyncHeadV1>,
     local: &SyncTrustV1,
 ) -> AppResult<()> {
@@ -1166,14 +1245,15 @@ fn ensure_remote_trust_matches(
             author_cert_id,
             author_chain_hash,
         )?;
-        let expected_signature = sign_sync_payload(&payload);
-        if expected_signature != author_signature {
+        let legacy_signature = legacy_sync_signature(&payload);
+        if verify_sync_head_author_signature_v1(conn, head).is_err()
+            && legacy_signature != author_signature
+        {
             return Err(sync_error(
                 "KC_TRUST_SIGNATURE_INVALID",
                 "sync head v3 signature mismatch",
                 serde_json::json!({
                     "snapshot_id": head.snapshot_id,
-                    "expected": expected_signature,
                     "actual": author_signature
                 }),
             ));
@@ -1695,15 +1775,19 @@ fn sync_push_s3_target(
             trust: Some(local_trust.clone()),
             author_device_id: Some(local_author.device_id.clone()),
             author_fingerprint: Some(local_author.fingerprint.clone()),
-            author_signature: Some(sign_sync_payload(&sync_signature_payload(
-                &snapshot_id,
-                &local_manifest_hash,
-                now_ms,
+            author_signature: Some(sign_sync_payload(
+                conn,
                 &local_author.device_id,
-                &local_author.fingerprint,
-                &local_author.cert_id,
-                &local_author.chain_hash,
-            )?)),
+                &sync_signature_payload(
+                    &snapshot_id,
+                    &local_manifest_hash,
+                    now_ms,
+                    &local_author.device_id,
+                    &local_author.fingerprint,
+                    &local_author.cert_id,
+                    &local_author.chain_hash,
+                )?,
+            )?),
             author_cert_id: Some(local_author.cert_id.clone()),
             author_chain_hash: Some(local_author.chain_hash.clone()),
         };
@@ -2210,11 +2294,20 @@ pub fn sync_pull_target_with_mode(
 #[cfg(test)]
 mod tests {
     use super::{
-        unpack_zip_snapshot, unpack_zip_snapshot_with_limits, validate_snapshot_dir_limits,
-        SyncSnapshotResourceLimits,
+        bytes_to_hex, sign_sync_payload, sync_signature_payload, unpack_zip_snapshot,
+        unpack_zip_snapshot_with_limits, validate_snapshot_dir_limits, SyncSnapshotResourceLimits,
     };
+    use crate::db::apply_migrations;
+    use crate::trust::format_device_fingerprint;
+    use ed25519_dalek::{Signer, SigningKey};
     use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
     use zip::write::SimpleFileOptions;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn zip_bytes(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut bytes = std::io::Cursor::new(Vec::new());
@@ -2326,5 +2419,39 @@ mod tests {
         .expect_err("oversized snapshot dir entry should fail");
 
         assert_eq!(err.code, "KC_RESOURCE_LIMIT_EXCEEDED");
+    }
+
+    #[test]
+    fn sync_signing_uses_env_ed25519_key_when_it_matches_trusted_device() {
+        let _guard = env_lock().lock().expect("env lock");
+        let conn = rusqlite::Connection::open_in_memory().expect("open db");
+        apply_migrations(&conn).expect("migrations");
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let device_id = "device-1";
+        let pubkey_hex = bytes_to_hex(&key.verifying_key().to_bytes());
+        let fingerprint = format_device_fingerprint(&key.verifying_key().to_bytes());
+        conn.execute(
+            "INSERT INTO trusted_devices(device_id, label, pubkey, fingerprint, verified_at_ms, created_at_ms)
+             VALUES(?1, 'fixture', ?2, ?3, 10, 9)",
+            rusqlite::params![device_id, pubkey_hex, fingerprint],
+        )
+        .expect("insert trusted device");
+
+        std::env::set_var("KC_SYNC_AUTHOR_SIGNING_KEY_HEX", bytes_to_hex(&[7u8; 32]));
+        let payload = sync_signature_payload(
+            "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            123456789,
+            device_id,
+            &fingerprint,
+            "cert-1",
+            "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        )
+        .expect("payload");
+
+        let signature = sign_sync_payload(&conn, device_id, &payload).expect("sign");
+        let expected = bytes_to_hex(&key.sign(&payload).to_bytes());
+        assert_eq!(signature, expected);
+        std::env::remove_var("KC_SYNC_AUTHOR_SIGNING_KEY_HEX");
     }
 }

--- a/crates/kc_core/src/sync_auth.rs
+++ b/crates/kc_core/src/sync_auth.rs
@@ -2,7 +2,10 @@
 
 use crate::app_error::{AppError, AppResult};
 use crate::canon_json::to_canonical_bytes;
+use crate::sync::SyncHeadV1;
+use crate::{trust, trust_identity};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use rusqlite::Connection;
 
 pub(crate) const SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1: &str = "ed25519_sync_head_v1";
 
@@ -108,10 +111,113 @@ pub(crate) fn verify_sync_author_signature_v1(
     })
 }
 
+pub(crate) fn verify_sync_head_author_signature_v1(
+    conn: &Connection,
+    head: &SyncHeadV1,
+) -> AppResult<()> {
+    if head.schema_version < 3 {
+        return Ok(());
+    }
+
+    let author_device_id =
+        required_author_field(head.author_device_id.as_deref(), head, "author_device_id")?;
+    let author_fingerprint = required_author_field(
+        head.author_fingerprint.as_deref(),
+        head,
+        "author_fingerprint",
+    )?;
+    let author_signature =
+        required_author_field(head.author_signature.as_deref(), head, "author_signature")?;
+    let author_cert_id =
+        required_author_field(head.author_cert_id.as_deref(), head, "author_cert_id")?;
+    let author_chain_hash =
+        required_author_field(head.author_chain_hash.as_deref(), head, "author_chain_hash")?;
+
+    trust_identity::verify_author_chain(conn, author_device_id, author_cert_id, author_chain_hash)
+        .map_err(|e| {
+            sync_auth_error(
+                "KC_TRUST_CERT_CHAIN_INVALID",
+                "sync head author certificate chain verification failed",
+                serde_json::json!({
+                    "source_code": e.code,
+                    "source_message": e.message,
+                    "snapshot_id": head.snapshot_id,
+                    "author_device_id": author_device_id,
+                    "author_cert_id": author_cert_id
+                }),
+            )
+        })?;
+
+    let author_pubkey = trust::trusted_device_public_key(conn, author_device_id).map_err(|e| {
+        sync_auth_error(
+            "KC_TRUST_DEVICE_UNVERIFIED",
+            "sync head author device public key is unavailable",
+            serde_json::json!({
+                "source_code": e.code,
+                "source_message": e.message,
+                "snapshot_id": head.snapshot_id,
+                "author_device_id": author_device_id
+            }),
+        )
+    })?;
+
+    let expected_fingerprint = trust::format_device_fingerprint(&parse_lower_hex_fixed::<32>(
+        &author_pubkey,
+        "author_pubkey",
+        "KC_TRUST_CERT_CHAIN_INVALID",
+    )?);
+    if expected_fingerprint != author_fingerprint {
+        return Err(sync_auth_error(
+            "KC_TRUST_FINGERPRINT_MISMATCH",
+            "sync head author fingerprint does not match trusted device key",
+            serde_json::json!({
+                "snapshot_id": head.snapshot_id,
+                "author_device_id": author_device_id,
+                "expected": expected_fingerprint,
+                "actual": author_fingerprint
+            }),
+        ));
+    }
+
+    let payload = canonical_sync_author_payload_v1(&SyncAuthorPayloadV1 {
+        snapshot_id: head.snapshot_id.clone(),
+        manifest_hash: head.manifest_hash.clone(),
+        created_at_ms: head.created_at_ms,
+        author_device_id: author_device_id.to_string(),
+        author_fingerprint: author_fingerprint.to_string(),
+        author_cert_id: author_cert_id.to_string(),
+        author_chain_hash: author_chain_hash.to_string(),
+    })?;
+    verify_sync_author_signature_v1(&payload, author_signature, &author_pubkey)
+}
+
+fn required_author_field<'a>(
+    value: Option<&'a str>,
+    head: &SyncHeadV1,
+    field: &str,
+) -> AppResult<&'a str> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            sync_auth_error(
+                "KC_TRUST_SIGNATURE_INVALID",
+                "sync head v3 is missing required author signature field",
+                serde_json::json!({
+                    "snapshot_id": head.snapshot_id,
+                    "field": field
+                }),
+            )
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::apply_migrations;
+    use crate::sync::SyncHeadV1;
+    use crate::trust::format_device_fingerprint;
     use ed25519_dalek::{Signer, SigningKey};
+    use rusqlite::Connection;
 
     fn bytes_to_hex(bytes: &[u8]) -> String {
         let mut out = String::with_capacity(bytes.len() * 2);
@@ -142,6 +248,55 @@ mod tests {
 
     fn signing_key(seed_byte: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed_byte; 32])
+    }
+
+    fn trusted_author_conn(key: &SigningKey) -> (Connection, SyncAuthorPayloadV1) {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        apply_migrations(&conn).expect("migrations");
+        let pubkey_hex = bytes_to_hex(&key.verifying_key().to_bytes());
+        let fingerprint = format_device_fingerprint(&key.verifying_key().to_bytes());
+        let payload = fixture_payload();
+
+        conn.execute(
+            "INSERT INTO trusted_devices(device_id, label, pubkey, fingerprint, verified_at_ms, created_at_ms)
+             VALUES(?1, 'fixture', ?2, ?3, 10, 9)",
+            rusqlite::params![payload.author_device_id, pubkey_hex, fingerprint],
+        )
+        .expect("insert trusted device");
+        conn.execute(
+            "INSERT INTO identity_providers(provider_id, issuer, audience, enabled, created_at_ms)
+             VALUES('default', 'https://default.oidc.knowledgecore.local', 'kc-desktop:default', 1, 10)",
+            [],
+        )
+        .expect("insert identity provider");
+        conn.execute(
+            "INSERT INTO device_certificates(
+               cert_id, device_id, provider_id, subject, cert_chain_hash, issued_at_ms, expires_at_ms, verified_at_ms, created_at_ms
+             )
+             VALUES(?1, ?2, 'default', 'sub:sync-author', ?3, 11, 3600011, 12, 11)",
+            rusqlite::params![
+                payload.author_cert_id,
+                payload.author_device_id,
+                payload.author_chain_hash
+            ],
+        )
+        .expect("insert device certificate");
+        (conn, payload)
+    }
+
+    fn head_for_payload(payload: &SyncAuthorPayloadV1, signature_hex: String) -> SyncHeadV1 {
+        SyncHeadV1 {
+            schema_version: 3,
+            snapshot_id: payload.snapshot_id.clone(),
+            manifest_hash: payload.manifest_hash.clone(),
+            created_at_ms: payload.created_at_ms,
+            trust: None,
+            author_device_id: Some(payload.author_device_id.clone()),
+            author_fingerprint: Some(payload.author_fingerprint.clone()),
+            author_signature: Some(signature_hex),
+            author_cert_id: Some(payload.author_cert_id.clone()),
+            author_chain_hash: Some(payload.author_chain_hash.clone()),
+        }
     }
 
     #[test]
@@ -222,5 +377,33 @@ mod tests {
         let err = verify_sync_author_signature_v1(&payload, &signature_hex, "abcd")
             .expect_err("short pubkey must fail");
         assert_eq!(err.code, "KC_TRUST_CERT_CHAIN_INVALID");
+    }
+
+    #[test]
+    fn sync_head_author_signature_v1_verifies_against_trusted_device_key() {
+        let key = signing_key(7);
+        let (conn, mut payload) = trusted_author_conn(&key);
+        payload.author_fingerprint = format_device_fingerprint(&key.verifying_key().to_bytes());
+        let payload_bytes = canonical_sync_author_payload_v1(&payload).expect("payload");
+        let signature = key.sign(&payload_bytes);
+        let head = head_for_payload(&payload, bytes_to_hex(&signature.to_bytes()));
+
+        verify_sync_head_author_signature_v1(&conn, &head).expect("head signature should verify");
+    }
+
+    #[test]
+    fn sync_head_author_signature_v1_rejects_tampered_head_payload() {
+        let key = signing_key(7);
+        let (conn, mut payload) = trusted_author_conn(&key);
+        payload.author_fingerprint = format_device_fingerprint(&key.verifying_key().to_bytes());
+        let payload_bytes = canonical_sync_author_payload_v1(&payload).expect("payload");
+        let signature = key.sign(&payload_bytes);
+        let mut head = head_for_payload(&payload, bytes_to_hex(&signature.to_bytes()));
+        head.manifest_hash =
+            "blake3:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string();
+
+        let err = verify_sync_head_author_signature_v1(&conn, &head)
+            .expect_err("tampered head must fail");
+        assert_eq!(err.code, "KC_TRUST_SIGNATURE_INVALID");
     }
 }

--- a/crates/kc_core/src/trust.rs
+++ b/crates/kc_core/src/trust.rs
@@ -214,6 +214,24 @@ pub fn trust_device_list(conn: &Connection) -> AppResult<Vec<TrustedDeviceRecord
     Ok(out)
 }
 
+pub fn trusted_device_public_key(conn: &Connection, device_id: &str) -> AppResult<String> {
+    let Some(device) = load_device(conn, device_id)? else {
+        return Err(trust_error(
+            "KC_TRUST_DEVICE_UNVERIFIED",
+            "device is not present in trust registry",
+            serde_json::json!({ "device_id": device_id }),
+        ));
+    };
+    if device.verified_at_ms.is_none() {
+        return Err(trust_error(
+            "KC_TRUST_DEVICE_UNVERIFIED",
+            "device is not verified",
+            serde_json::json!({ "device_id": device_id }),
+        ));
+    }
+    Ok(device.pubkey)
+}
+
 pub fn trust_device_verify(
     conn: &Connection,
     device_id: &str,


### PR DESCRIPTION
## Summary
- add sync-head author verification against trusted Ed25519 device keys
- add a trusted-device public-key lookup for verified devices
- add env-gated sync-head Ed25519 signing via `KC_SYNC_AUTHOR_SIGNING_KEY_HEX`
- keep the legacy deterministic signature fallback for compatibility until durable signing-key custody is designed

## Verification
- `cargo fmt --all --check`
- `cargo test -p kc_core sync_auth`
- `cargo test -p kc_core sync_signing_uses_env_ed25519_key_when_it_matches_trusted_device`
- `cargo test -p kc_core sync_s3_key_mismatch_hard_fails`
- `cargo test -p kc_core sync_target_wrappers_support_s3_uri_with_emulation`
- `cargo clippy -p kc_core --all-targets -- -D warnings`

## Risk note
This reduces the critical sync-auth exposure by adding real Ed25519 verification and an opt-in signer, but it intentionally does not remove legacy deterministic signature acceptance yet. The remaining strict-enforcement/key-custody lane should be handled separately.