### PR TITLE
docs: update sync authorship hardening checkpoint

### DIFF
--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -58,7 +58,8 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Stale dependency-watch and RustSec policy entries for removed LanceDB/Tantivy/Rand transitives were pruned.
 - Sync authorship hardening is captured as an approval-gated plan in `docs/20-sync-authorship-hardening-plan-2026-06-19.md`.
 - UI lint, test, build, and typecheck gates passed from a temp deploy using lockfile package versions because repo-local `pnpm install` remains tool-policy blocked; `node_modules/.pnpm` content exists, but `apps/desktop/ui/node_modules` is still absent.
-- Non-migrating Ed25519 sync authorship verification helpers and tests were added behind the still-unwired `kc_core::sync_auth` module.
+- Compatible Ed25519 sync authorship verification is now wired for v3 heads: incoming heads prefer Ed25519 verification against the trusted device public key and verified certificate chain, with legacy BLAKE3-derived signatures still accepted for compatibility.
+- S3 sync emits Ed25519 author signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it preserves legacy v3 signature emission.
 - Recovery verification now decrypts `key_blob.enc` with the recovery phrase-derived key, checks the deterministic recovery nonce, rejects empty restored passphrases, and includes regressions for matching-hash forged blobs that cannot decrypt.
 - DB encryption lifecycle tests now pin unsupported mode/KDF rejection, idempotent already-encrypted migration detection, wrong-key failure for encrypted DB migration, and absence of stale `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
 - SQLCipher production state semantics are captured as an approval-gated design note in `docs/21-sqlcipher-state-model-plan-2026-06-19.md`; the documented decision is a future `vault.json` v4 `db_encryption.state` boundary, with no schema or runtime behavior changed in this lane.
@@ -69,7 +70,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Approved production resource-limit defaults and wiring slices are captured in `docs/23-production-resource-limits-decision-2026-06-19.md`; CLI/RPC ingest, default PDF byte extraction, OCR page-count validation, S3 sync pull zip extraction, filesystem snapshot directory apply preflight, and CLI index rebuild now pass default limits.
 
 ## Current Risk Posture
-- Critical: sync head v3 authorship is still not a cryptographic Ed25519 signature. The current implementation derives the author signature from public BLAKE3 inputs.
+- High: sync head v3 authorship now supports Ed25519 verification and env-key signing, but legacy BLAKE3-derived signatures are still accepted for compatibility until key custody, schema/algorithm signaling, and fallback removal are approved.
 - High: object-store KDF metadata still has a constant default salt id. Any per-vault random salt change requires explicit migration design approval.
 - High: SQLCipher enable/migrate lifecycle has status-only state derivation and a v4 explicit-state decision, but persisting `db_encryption.state` remains approval-gated.
 - Medium: recovery verification, generated-fixture restore drill coverage, opt-in resource-limit tests, and approved production resource-limit wiring slices are in place; future resource-limit work should focus on compatibility tuning and any newly approved surfaces.
@@ -86,7 +87,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Do not promote S3 sync, managed identity, or recovery escrow to production-ready until their current risk items are resolved and verified.
 
 ## Next Recommended Lane
-1. Decide key custody and schema transition for wiring Ed25519 signed sync heads into runtime acceptance.
+1. Decide key custody, schema/algorithm signaling, and rollout timing for removing the legacy v3 BLAKE3-derived sync signature fallback.
 2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
 3. Decide whether non-OCR PDF page-count limits are needed beyond the current PDF byte and OCR page-count guardrails.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.

--- a/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
@@ -6,37 +6,39 @@ Capture the approval-gated implementation contract for fixing sync head authorsh
 ## Verified Current Behavior
 - `SyncHeadV1` stores `author_device_id`, `author_fingerprint`, `author_signature`, `author_cert_id`, and `author_chain_hash` for schema version 3 heads.
 - `sync_signature_payload` canonicalizes public sync fields: `snapshot_id`, `manifest_hash`, `created_at_ms`, device id, fingerprint, certificate id, and chain hash.
-- `sign_sync_payload` does not use Ed25519. It returns a 128-character hex value made from two BLAKE3 hashes over public payload material.
-- `ensure_remote_trust_matches` validates v3 `author_signature` by recomputing `sign_sync_payload` from the remote head fields.
+- `sign_sync_payload` now uses Ed25519 when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is provided and matches the verified local author device public key.
+- If no signing key env var is present, `sign_sync_payload` still emits the legacy 128-character BLAKE3-derived pseudo-signature for compatibility.
+- `ensure_remote_trust_matches` now prefers Ed25519 verification against the local trusted-device public key and verified certificate chain, then falls back to the legacy pseudo-signature for existing v3 heads.
 - `expected_cert_chain_hash` is also derived from public certificate/device/fingerprint fields.
 - Trusted devices store an Ed25519 public key in `trusted_devices.pubkey`, but the generated private signing key is not persisted by the current trust-device flow.
 
 ## Security Risk
-The current v3 author signature proves deterministic formatting, not authorship. A party that can write a remote sync head and snapshot can recompute the expected `author_signature` from public fields. This does not provide Ed25519 authenticity and must not be treated as production-grade signed sync.
+Legacy v3 author signatures still prove deterministic formatting, not authorship. A party that can write a remote sync head and snapshot can recompute the legacy `author_signature` from public fields, so the compatibility fallback must not be treated as production-grade signed sync. Ed25519-authored heads are now verifiable, but full production enforcement still depends on key custody and fallback-removal decisions.
 
 ## Design Goal
 Remote sync heads should be accepted only when authorship is verified against an approved trust chain and a real Ed25519 signature over a versioned canonical sync payload.
 
 ## Required Design Decisions
-- Key custody: choose how the local Ed25519 private key is generated, stored, unlocked, rotated, backed up, and deleted.
+- Key custody: choose how the local Ed25519 private key is generated, stored, unlocked, rotated, backed up, and deleted without relying on an env var.
 - Wire compatibility: decide whether to keep schema version 3 with an explicit `author_signature_alg` field or introduce sync head schema version 4.
 - Trust source: decide whether remote author certificates must already exist in the local DB, be carried in the signed snapshot, or be verified through another explicit trust-import flow.
 - Certificate state: define how expiration, revocation, and provider/session status affect sync acceptance.
-- Rollout: define read/write compatibility for existing v1/v2/v3 heads and the exact point at which forged-hash v3 heads become hard failures.
+- Rollout: define read/write compatibility for existing v1/v2/v3 heads and the exact point at which legacy BLAKE3-derived v3 signatures become hard failures.
 
 ## Safest Implementation Slice
-1. Add test fixtures for a canonical Ed25519 sync signature payload and verification result.
-2. Add non-migrating verification helpers that accept `(payload, signature, verifying_key)` and reject tampered payloads, unknown keys, malformed signatures, and chain mismatches.
-3. Add sync acceptance tests for file and S3-emulated transports that prove forged BLAKE3-derived author signatures are rejected once the new signed-head mode is enabled.
-4. Only after design approval, wire the helpers into sync head read/write paths behind an explicit schema/algorithm transition.
+1. Done: add test fixtures for a canonical Ed25519 sync signature payload and verification result.
+2. Done: add non-migrating verification helpers that reject tampered payloads, unknown keys, malformed signatures, fingerprint mismatches, and chain mismatches.
+3. Done: add compatible runtime support that signs with Ed25519 only when an explicit env-provided signing key matches the verified local author device.
+4. Remaining: approve key custody, schema/algorithm signaling, remote trust import, and the point at which legacy BLAKE3-derived author signatures become hard failures.
 
 ## Implementation Checkpoint
 - Added a private `kc_core::sync_auth` helper module for future Ed25519 signed-head work.
 - Added canonical payload construction with an explicit `signature_alg = "ed25519_sync_head_v1"` domain separator.
-- Added Ed25519 verification against a supplied author public key.
-- Added tests for canonical payload stability, valid signature verification, tampered payload rejection, wrong-key rejection, malformed signature rejection, and malformed public-key rejection.
-- This checkpoint is intentionally non-migrating and not wired into sync head read/write acceptance yet.
-- No sync head schema, vault storage, private-key custody, remote trust bootstrapping, or cloud behavior changed in this checkpoint.
+- Added Ed25519 verification against the trusted author device public key and verified certificate chain.
+- Added tests for canonical payload stability, valid signature verification, tampered payload rejection, wrong-key rejection, malformed signature rejection, malformed public-key rejection, trusted-head verification, tampered-head rejection, and env-key signing.
+- Wired compatible runtime acceptance: Ed25519 is preferred for v3 remote heads and legacy BLAKE3-derived signatures remain accepted for existing heads.
+- Wired compatible runtime emission: S3 sync emits Ed25519 signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it keeps legacy emission.
+- No sync head schema, vault storage, private-key persistence, remote trust bootstrapping, or cloud behavior changed in this checkpoint.
 
 ## Verification Expectations
 - `cargo test -p kc_core --test sync`
@@ -49,7 +51,7 @@ Remote sync heads should be accepted only when authorship is verified against an
 - `node scripts/dependency-watch.mjs`
 
 ## Approval Gates
-- Do not change sync head schema, accepted signature semantics, or vault storage without explicit design approval.
+- Do not remove the legacy v3 signature fallback, change sync head schema, or change vault storage without explicit design approval.
 - Do not persist private keys until key custody is approved.
 - Do not introduce background sync, automatic cloud sync, or new remote trust bootstrapping in this lane.
 - Do not mark S3 sync or managed identity production-ready until signed-head acceptance, recovery, and resource-limit gates are green.


### PR DESCRIPTION
## Summary
- Refresh the security readiness checkpoint to reflect compatible Ed25519 sync-head verification and env-key signing support.
- Update the sync authorship hardening plan with completed implementation slices and remaining approval gates.
- Preserve the no-format-migration, no-private-key-persistence, no-background-sync boundary.

## Verification
- `git diff --check` passed locally after resolving the accidental stale-stash `AGENTS.md` conflict.
- Earlier implementation lane verification passed: `cargo fmt --all -- --check`, `cargo check -p kc_core -p kc_cli`, sync-auth/core/CLI/Tauri tests, workspace tests excluding/including Tauri, and desktop build.
- `run-codex-evals` was retried and is currently blocked by Ollama model warmup failure for `qwen2.5-coder:14b` while another `promptfoo eval` workload is active.

## Approval gates still in force
- Do not remove the legacy v3 signature fallback without explicit design approval.
- Do not persist sync private keys until key custody is approved.
- Do not change vault schema/format or introduce background/cloud sync in this docs checkpoint.