### PR TITLE
feat: enforce declared sync head signature algorithm

### DIFF
--- a/crates/kc_core/src/sync.rs
+++ b/crates/kc_core/src/sync.rs
@@ -4,7 +4,9 @@ use crate::db::open_db;
 use crate::export::{export_bundle, ExportOptions};
 use crate::hashing::blake3_hex_prefixed;
 use crate::resource_limits::sync_snapshot_limits;
-use crate::sync_auth::verify_sync_head_author_signature_v1;
+use crate::sync_auth::{
+    verify_sync_head_author_signature_v1, SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1,
+};
 use crate::sync_merge::{
     ensure_conservative_merge_safe, ensure_conservative_plus_v2_merge_safe,
     ensure_conservative_plus_v3_merge_safe, ensure_conservative_plus_v4_merge_safe,
@@ -62,6 +64,8 @@ pub struct SyncHeadV1 {
     pub author_fingerprint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author_signature_alg: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author_cert_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1236,6 +1240,29 @@ fn ensure_remote_trust_matches(
             ));
         }
 
+        let signature_alg = head
+            .author_signature_alg
+            .as_deref()
+            .map(str::trim)
+            .filter(|alg| !alg.is_empty());
+        match signature_alg {
+            Some(SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1) => {
+                verify_sync_head_author_signature_v1(conn, head)?;
+                return Ok(());
+            }
+            Some(actual) => {
+                return Err(sync_error(
+                    "KC_TRUST_SIGNATURE_INVALID",
+                    "sync head v3 declares unsupported author signature algorithm",
+                    serde_json::json!({
+                        "snapshot_id": head.snapshot_id,
+                        "actual": actual
+                    }),
+                ));
+            }
+            None => {}
+        }
+
         let payload = sync_signature_payload(
             &head.snapshot_id,
             &head.manifest_hash,
@@ -1660,6 +1687,7 @@ pub fn sync_push(
         author_device_id: None,
         author_fingerprint: None,
         author_signature: None,
+        author_signature_alg: None,
         author_cert_id: None,
         author_chain_hash: None,
     };
@@ -1788,6 +1816,7 @@ fn sync_push_s3_target(
                     &local_author.chain_hash,
                 )?,
             )?),
+            author_signature_alg: None,
             author_cert_id: Some(local_author.cert_id.clone()),
             author_chain_hash: Some(local_author.chain_hash.clone()),
         };
@@ -2294,11 +2323,15 @@ pub fn sync_pull_target_with_mode(
 #[cfg(test)]
 mod tests {
     use super::{
-        bytes_to_hex, sign_sync_payload, sync_signature_payload, unpack_zip_snapshot,
-        unpack_zip_snapshot_with_limits, validate_snapshot_dir_limits, SyncSnapshotResourceLimits,
+        bytes_to_hex, ensure_remote_trust_matches, legacy_sync_signature, sign_sync_payload,
+        sync_signature_payload, unpack_zip_snapshot, unpack_zip_snapshot_with_limits,
+        validate_snapshot_dir_limits, SyncHeadV1, SyncSnapshotResourceLimits, SyncTrustV1,
+        TRUST_MODEL_PASSPHRASE_V1,
     };
     use crate::db::apply_migrations;
+    use crate::sync_auth::SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1;
     use crate::trust::format_device_fingerprint;
+    use crate::trust_identity;
     use ed25519_dalek::{Signer, SigningKey};
     use std::io::Write;
     use std::sync::{Mutex, OnceLock};
@@ -2453,5 +2486,105 @@ mod tests {
         let expected = bytes_to_hex(&key.sign(&payload).to_bytes());
         assert_eq!(signature, expected);
         std::env::remove_var("KC_SYNC_AUTHOR_SIGNING_KEY_HEX");
+    }
+
+    fn trusted_author_fixture(
+        key: &SigningKey,
+    ) -> (rusqlite::Connection, SyncTrustV1, SyncHeadV1, Vec<u8>) {
+        let conn = rusqlite::Connection::open_in_memory().expect("open db");
+        apply_migrations(&conn).expect("migrations");
+        let device_id = "device-1";
+        let cert_id = "cert-1";
+        let pubkey_hex = bytes_to_hex(&key.verifying_key().to_bytes());
+        let fingerprint = format_device_fingerprint(&key.verifying_key().to_bytes());
+        let chain_hash = trust_identity::expected_cert_chain_hash(cert_id, device_id, &fingerprint);
+        conn.execute(
+            "INSERT INTO trusted_devices(device_id, label, pubkey, fingerprint, verified_at_ms, created_at_ms)
+             VALUES(?1, 'fixture', ?2, ?3, 10, 9)",
+            rusqlite::params![device_id, pubkey_hex, fingerprint],
+        )
+        .expect("insert trusted device");
+        conn.execute(
+            "INSERT INTO identity_providers(provider_id, issuer, audience, enabled, created_at_ms)
+             VALUES('default', 'https://default.oidc.knowledgecore.local', 'kc-desktop:default', 1, 10)",
+            [],
+        )
+        .expect("insert identity provider");
+        conn.execute(
+            "INSERT INTO device_certificates(
+               cert_id, device_id, provider_id, subject, cert_chain_hash, issued_at_ms, expires_at_ms, verified_at_ms, created_at_ms
+             )
+             VALUES(?1, ?2, 'default', 'sub:sync-author', ?3, 11, 3600011, 12, 11)",
+            rusqlite::params![cert_id, device_id, chain_hash],
+        )
+        .expect("insert device certificate");
+
+        let trust = SyncTrustV1 {
+            model: TRUST_MODEL_PASSPHRASE_V1.to_string(),
+            fingerprint: "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                .to_string(),
+            updated_at_ms: 123,
+        };
+        let payload = sync_signature_payload(
+            "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            123456789,
+            device_id,
+            &fingerprint,
+            cert_id,
+            &chain_hash,
+        )
+        .expect("payload");
+        let head = SyncHeadV1 {
+            schema_version: 3,
+            snapshot_id: "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+            manifest_hash:
+                "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    .to_string(),
+            created_at_ms: 123456789,
+            trust: Some(trust.clone()),
+            author_device_id: Some(device_id.to_string()),
+            author_fingerprint: Some(fingerprint),
+            author_signature: None,
+            author_signature_alg: None,
+            author_cert_id: Some(cert_id.to_string()),
+            author_chain_hash: Some(chain_hash),
+        };
+        (conn, trust, head, payload)
+    }
+
+    #[test]
+    fn declared_ed25519_sync_head_rejects_legacy_fallback_signature() {
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let (conn, trust, mut head, payload) = trusted_author_fixture(&key);
+        head.author_signature = Some(legacy_sync_signature(&payload));
+        head.author_signature_alg = Some(SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1.to_string());
+
+        let err = ensure_remote_trust_matches(&conn, Some(&head), &trust)
+            .expect_err("declared Ed25519 head must not use legacy fallback");
+        assert_eq!(err.code, "KC_TRUST_SIGNATURE_INVALID");
+    }
+
+    #[test]
+    fn unknown_sync_head_signature_algorithm_is_rejected() {
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let (conn, trust, mut head, payload) = trusted_author_fixture(&key);
+        head.author_signature = Some(legacy_sync_signature(&payload));
+        head.author_signature_alg = Some("ed25519_sync_head_v2".to_string());
+
+        let err = ensure_remote_trust_matches(&conn, Some(&head), &trust)
+            .expect_err("unknown algorithm must fail");
+        assert_eq!(err.code, "KC_TRUST_SIGNATURE_INVALID");
+    }
+
+    #[test]
+    fn undeclared_v3_sync_head_still_accepts_legacy_signature_during_transition() {
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let (conn, trust, mut head, payload) = trusted_author_fixture(&key);
+        head.author_signature = Some(legacy_sync_signature(&payload));
+
+        ensure_remote_trust_matches(&conn, Some(&head), &trust)
+            .expect("undeclared v3 legacy fallback remains compatible");
     }
 }

--- a/crates/kc_core/src/sync_auth.rs
+++ b/crates/kc_core/src/sync_auth.rs
@@ -294,6 +294,7 @@ mod tests {
             author_device_id: Some(payload.author_device_id.clone()),
             author_fingerprint: Some(payload.author_fingerprint.clone()),
             author_signature: Some(signature_hex),
+            author_signature_alg: None,
             author_cert_id: Some(payload.author_cert_id.clone()),
             author_chain_hash: Some(payload.author_chain_hash.clone()),
         }

--- a/crates/kc_core/tests/schema_sync_manifest.rs
+++ b/crates/kc_core/tests/schema_sync_manifest.rs
@@ -30,6 +30,10 @@ fn sync_head_schema() -> serde_json::Value {
           "type": ["string", "null"],
           "pattern": "^[0-9a-f]{128}$"
         },
+        "author_signature_alg": {
+          "type": ["string", "null"],
+          "enum": ["ed25519_sync_head_v1", null]
+        },
         "author_cert_id": { "type": ["string", "null"] },
         "author_chain_hash": { "type": ["string", "null"], "pattern": "^blake3:[0-9a-f]{64}$" }
       },
@@ -103,10 +107,34 @@ fn schema_sync_head_accepts_valid_payload() {
       "author_device_id": "f7ca3e7b-e380-4896-bde1-b2de37789b22",
       "author_fingerprint": "aaaaaaaa:bbbbbbbb:cccccccc:dddddddd:eeeeeeee:ffffffff:11111111:22222222",
       "author_signature": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "author_signature_alg": "ed25519_sync_head_v1",
       "author_cert_id": "4f299112-e7a9-4956-bc63-f24847c110ca",
       "author_chain_hash": "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     });
     assert!(schema.is_valid(&payload));
+}
+
+#[test]
+fn schema_sync_head_rejects_unknown_author_signature_algorithm() {
+    let schema = validator_for(&sync_head_schema()).expect("compile sync head schema");
+    let payload = serde_json::json!({
+      "schema_version": 3,
+      "snapshot_id": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "manifest_hash": "blake3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "created_at_ms": 100,
+      "trust": {
+        "model": "passphrase_v1",
+        "fingerprint": "blake3:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "updated_at_ms": 100
+      },
+      "author_device_id": "f7ca3e7b-e380-4896-bde1-b2de37789b22",
+      "author_fingerprint": "aaaaaaaa:bbbbbbbb:cccccccc:dddddddd:eeeeeeee:ffffffff:11111111:22222222",
+      "author_signature": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "author_signature_alg": "ed25519_sync_head_v2",
+      "author_cert_id": "4f299112-e7a9-4956-bc63-f24847c110ca",
+      "author_chain_hash": "blake3:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    });
+    assert!(!schema.is_valid(&payload));
 }
 
 #[test]

--- a/crates/kc_core/tests/sync.rs
+++ b/crates/kc_core/tests/sync.rs
@@ -120,6 +120,7 @@ fn sync_push_conflict_emits_artifact() {
         author_device_id: None,
         author_fingerprint: None,
         author_signature: None,
+        author_signature_alg: None,
         author_cert_id: None,
         author_chain_hash: None,
     };

--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -60,6 +60,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - UI lint, test, build, and typecheck gates passed from a temp deploy using lockfile package versions because repo-local `pnpm install` remains tool-policy blocked; `node_modules/.pnpm` content exists, but `apps/desktop/ui/node_modules` is still absent.
 - Compatible Ed25519 sync authorship verification is now wired for v3 heads: incoming heads prefer Ed25519 verification against the trusted device public key and verified certificate chain, with legacy BLAKE3-derived signatures still accepted for compatibility.
 - S3 sync emits Ed25519 author signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it preserves legacy v3 signature emission.
+- Sync head parsing now supports optional `author_signature_alg = "ed25519_sync_head_v1"` as a v3 extension. Declared Ed25519 heads must pass Ed25519 verification and cannot fall back to legacy BLAKE3-derived signatures; unknown declared algorithms fail closed.
 - Recovery verification now decrypts `key_blob.enc` with the recovery phrase-derived key, checks the deterministic recovery nonce, rejects empty restored passphrases, and includes regressions for matching-hash forged blobs that cannot decrypt.
 - DB encryption lifecycle tests now pin unsupported mode/KDF rejection, idempotent already-encrypted migration detection, wrong-key failure for encrypted DB migration, and absence of stale `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
 - SQLCipher production state semantics are captured as an approval-gated design note in `docs/21-sqlcipher-state-model-plan-2026-06-19.md`; the documented decision is a future `vault.json` v4 `db_encryption.state` boundary, with no schema or runtime behavior changed in this lane.
@@ -70,7 +71,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Approved production resource-limit defaults and wiring slices are captured in `docs/23-production-resource-limits-decision-2026-06-19.md`; CLI/RPC ingest, default PDF byte extraction, OCR page-count validation, S3 sync pull zip extraction, filesystem snapshot directory apply preflight, and CLI index rebuild now pass default limits.
 
 ## Current Risk Posture
-- High: sync head v3 authorship now supports Ed25519 verification and env-key signing, but legacy BLAKE3-derived signatures are still accepted for compatibility until key custody, schema/algorithm signaling, and fallback removal are approved.
+- High: sync head v3 authorship now supports Ed25519 verification, env-key signing, and strict declared-algorithm enforcement, but undeclared legacy BLAKE3-derived signatures are still accepted for compatibility until key custody and fallback removal are approved.
 - High: object-store KDF metadata still has a constant default salt id. Any per-vault random salt change requires explicit migration design approval.
 - High: SQLCipher enable/migrate lifecycle has status-only state derivation and a v4 explicit-state decision, but persisting `db_encryption.state` remains approval-gated.
 - Medium: recovery verification, generated-fixture restore drill coverage, opt-in resource-limit tests, and approved production resource-limit wiring slices are in place; future resource-limit work should focus on compatibility tuning and any newly approved surfaces.
@@ -87,7 +88,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Do not promote S3 sync, managed identity, or recovery escrow to production-ready until their current risk items are resolved and verified.
 
 ## Next Recommended Lane
-1. Decide key custody, schema/algorithm signaling, and rollout timing for removing the legacy v3 BLAKE3-derived sync signature fallback.
+1. Decide key custody and rollout timing for removing the undeclared legacy v3 BLAKE3-derived sync signature fallback.
 2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
 3. Decide whether non-OCR PDF page-count limits are needed beyond the current PDF byte and OCR page-count guardrails.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.

--- a/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
@@ -9,6 +9,7 @@ Capture the approval-gated implementation contract for fixing sync head authorsh
 - `sign_sync_payload` now uses Ed25519 when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is provided and matches the verified local author device public key.
 - If no signing key env var is present, `sign_sync_payload` still emits the legacy 128-character BLAKE3-derived pseudo-signature for compatibility.
 - `ensure_remote_trust_matches` now prefers Ed25519 verification against the local trusted-device public key and verified certificate chain, then falls back to the legacy pseudo-signature for existing v3 heads.
+- `author_signature_alg = "ed25519_sync_head_v1"` is supported as an optional v3 extension. When present, Ed25519 verification is mandatory and legacy fallback is forbidden; unknown non-empty algorithms are rejected.
 - `expected_cert_chain_hash` is also derived from public certificate/device/fingerprint fields.
 - Trusted devices store an Ed25519 public key in `trusted_devices.pubkey`, but the generated private signing key is not persisted by the current trust-device flow.
 
@@ -20,7 +21,7 @@ Remote sync heads should be accepted only when authorship is verified against an
 
 ## Required Design Decisions
 - Key custody: choose how the local Ed25519 private key is generated, stored, unlocked, rotated, backed up, and deleted without relying on an env var.
-- Wire compatibility: decide whether to keep schema version 3 with an explicit `author_signature_alg` field or introduce sync head schema version 4.
+- Wire compatibility: `author_signature_alg` is implemented as an optional schema-version-3 extension for read/validation; writer behavior is still unchanged until key custody is approved.
 - Trust source: decide whether remote author certificates must already exist in the local DB, be carried in the signed snapshot, or be verified through another explicit trust-import flow.
 - Certificate state: define how expiration, revocation, and provider/session status affect sync acceptance.
 - Rollout: define read/write compatibility for existing v1/v2/v3 heads and the exact point at which legacy BLAKE3-derived v3 signatures become hard failures.
@@ -29,7 +30,8 @@ Remote sync heads should be accepted only when authorship is verified against an
 1. Done: add test fixtures for a canonical Ed25519 sync signature payload and verification result.
 2. Done: add non-migrating verification helpers that reject tampered payloads, unknown keys, malformed signatures, fingerprint mismatches, and chain mismatches.
 3. Done: add compatible runtime support that signs with Ed25519 only when an explicit env-provided signing key matches the verified local author device.
-4. Remaining: approve key custody, schema/algorithm signaling, remote trust import, and the point at which legacy BLAKE3-derived author signatures become hard failures.
+4. Done: add optional algorithm parsing and strict declared-Ed25519 acceptance semantics.
+5. Remaining: approve key custody, remote trust import, and the point at which undeclared legacy BLAKE3-derived author signatures become hard failures.
 
 ## Implementation Checkpoint
 - Added a private `kc_core::sync_auth` helper module for future Ed25519 signed-head work.
@@ -38,6 +40,7 @@ Remote sync heads should be accepted only when authorship is verified against an
 - Added tests for canonical payload stability, valid signature verification, tampered payload rejection, wrong-key rejection, malformed signature rejection, malformed public-key rejection, trusted-head verification, tampered-head rejection, and env-key signing.
 - Wired compatible runtime acceptance: Ed25519 is preferred for v3 remote heads and legacy BLAKE3-derived signatures remain accepted for existing heads.
 - Wired compatible runtime emission: S3 sync emits Ed25519 signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it keeps legacy emission.
+- Wired optional `author_signature_alg` parsing for v3 heads; declared `ed25519_sync_head_v1` heads require Ed25519 success, and unknown algorithms fail closed.
 - No sync head schema, vault storage, private-key persistence, remote trust bootstrapping, or cloud behavior changed in this checkpoint.
 
 ## Verification Expectations

--- a/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
+++ b/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
@@ -5,7 +5,7 @@ Define the approval-gated design lane for moving sync authorship from compatible
 
 ## Verified Current State
 - `SyncHeadV1` currently has `schema_version`, `snapshot_id`, `manifest_hash`, `created_at_ms`, `trust`, `author_device_id`, `author_fingerprint`, `author_signature`, `author_cert_id`, and `author_chain_hash`.
-- There is no persisted `author_signature_alg` field today.
+- `author_signature_alg` is now accepted as an optional schema-version-3 extension on read/validation, but writers still omit it.
 - `sync_auth::canonical_sync_author_payload_v1` domain-separates Ed25519 payloads with `signature_alg = "ed25519_sync_head_v1"` inside the canonical bytes.
 - `verify_sync_head_author_signature_v1` verifies v3 author fields against the trusted device public key and verified certificate chain.
 - `ensure_remote_trust_matches` prefers Ed25519 verification, then accepts the legacy BLAKE3-derived signature when Ed25519 verification fails.
@@ -33,18 +33,25 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - Support explicit deletion by removing encrypted private-key material without deleting historical public trust records needed for verification.
 
 ## Schema and Compatibility Contract
-- Add an explicit `author_signature_alg` field for newly authored Ed25519 heads, with value `ed25519_sync_head_v1`.
+- Add an explicit `author_signature_alg` field for future newly authored Ed25519 heads, with value `ed25519_sync_head_v1`, after writer/key-custody approval.
 - Continue accepting schema-version-3 heads without `author_signature_alg` only through the documented legacy fallback window.
 - For heads with `author_signature_alg = "ed25519_sync_head_v1"`, require Ed25519 verification success and do not fall back to the legacy pseudo-signature.
 - Reject unknown non-empty `author_signature_alg` values with `KC_TRUST_SIGNATURE_INVALID` or a narrower sync-auth error code.
 - Decide separately whether the field ships as schema version 3 extension or as schema version 4. Do not implement either path without fixture and migration/compatibility coverage.
 
 ## Safest First Implementation Slice
-1. Add parser/validator support for optional `author_signature_alg` on `SyncHeadV1` without changing writer behavior.
-2. Add generated fixtures for legacy v3, v3 plus `ed25519_sync_head_v1`, and unknown-algorithm heads.
-3. Change acceptance semantics only for heads that explicitly declare `ed25519_sync_head_v1`: Ed25519 success required; legacy fallback forbidden.
-4. Keep writer behavior unchanged until key custody is implemented; env-key signing may continue to emit compatibility heads unless a separate approval updates emission.
-5. Add tests proving unknown algorithms fail, declared Ed25519 rejects tampering, and legacy undeclared v3 remains accepted during the compatibility window.
+1. Done: add parser/validator support for optional `author_signature_alg` on `SyncHeadV1` without changing writer behavior.
+2. Done: add generated fixtures for legacy v3, v3 plus `ed25519_sync_head_v1`, and unknown-algorithm heads.
+3. Done: change acceptance semantics only for heads that explicitly declare `ed25519_sync_head_v1`: Ed25519 success required; legacy fallback forbidden.
+4. Done: keep writer behavior unchanged until key custody is implemented; env-key signing continues to emit compatibility heads.
+5. Done: add tests proving unknown algorithms fail, declared Ed25519 rejects tampering, and legacy undeclared v3 remains accepted during the compatibility window.
+
+## Implementation Checkpoint
+- `SyncHeadV1` now accepts optional `author_signature_alg` as a v3 extension and omits it from newly written heads.
+- The sync head schema validator allows only `ed25519_sync_head_v1` or `null` for `author_signature_alg`.
+- Declared `ed25519_sync_head_v1` remote heads require Ed25519 verification success and cannot fall back to the legacy BLAKE3-derived pseudo-signature.
+- Unknown non-empty declared algorithms fail with `KC_TRUST_SIGNATURE_INVALID`.
+- Undeclared v3 heads still accept the legacy compatibility fallback.
 
 ## Non-Goals
 - No cloud sync expansion.
@@ -55,7 +62,7 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - No removal of the legacy fallback until rollout timing is explicitly approved.
 
 ## Approval Gates
-- Implementing `author_signature_alg` in runtime code requires explicit approval of whether this is a v3 extension or schema v4.
+- Changing writer behavior to emit `author_signature_alg` requires explicit key-custody/writer approval.
 - Persisting private signing keys requires explicit key-custody implementation approval and tests for unlock, rotation, backup/recovery, and deletion behavior.
 - Removing the legacy fallback requires explicit rollout approval and compatibility evidence for existing heads.
 - Any vault metadata/schema change requires fixtures, downgrade/rollback expectations, and no private-document ingestion.
@@ -71,4 +78,4 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - `node scripts/dependency-watch.mjs`
 
 ## Done Criteria
-This design lane is done when the decision record is merged and the next implementation lane is limited to optional algorithm parsing plus declared-Ed25519 enforcement tests, with key persistence and fallback removal still approval-gated.
+This design lane is done when the decision record and optional algorithm enforcement slice are merged, with key persistence and undeclared legacy fallback removal still approval-gated.


### PR DESCRIPTION
## Summary
- add optional `author_signature_alg` support on `SyncHeadV1` as a v3 extension
- require Ed25519 verification when a head declares `ed25519_sync_head_v1`, with no legacy fallback
- reject unknown declared signature algorithms
- keep writer behavior unchanged and keep undeclared v3 legacy fallback during the compatibility window
- update docpack checkpoints and the key-custody decision record

## Verification
- `cargo fmt --all --check`
- `cargo test -p kc_core sync_auth`
- `cargo test -p kc_core sync_head`
- `cargo test -p kc_core --test schema_sync_manifest`
- `cargo test -p kc_core --test sync`
- `cargo test -p apps_desktop_tauri`
- `cargo test --workspace --exclude apps_desktop_tauri`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `node scripts/audit-rust.mjs`
- `node scripts/dependency-watch.mjs`

## Boundaries
- no private-key persistence
- no writer emission of `author_signature_alg`
- no removal of undeclared legacy v3 fallback
- no cloud/background sync expansion