### PR TITLE
feat: add sync signing key rotation

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -67,6 +67,13 @@ pub fn trust_device_signing_key_delete(
 }
 
 #[tauri::command]
+pub fn trust_device_signing_key_rotate(
+    req: rpc::TrustDeviceSigningKeyRotateReq,
+) -> rpc::RpcResponse<rpc::TrustDeviceSigningKeyRotateRes> {
+    rpc::trust_device_signing_key_rotate_rpc(req)
+}
+
+#[tauri::command]
 pub fn trust_provider_add(
     req: rpc::TrustProviderAddReq,
 ) -> rpc::RpcResponse<rpc::TrustProviderRes> {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
         commands::trust_device_list,
         commands::trust_device_signing_key_status,
         commands::trust_device_signing_key_delete,
+        commands::trust_device_signing_key_rotate,
         commands::trust_provider_add,
         commands::trust_provider_disable,
         commands::trust_provider_list,

--- a/apps/desktop/src-tauri/src/rpc.rs
+++ b/apps/desktop/src-tauri/src/rpc.rs
@@ -257,6 +257,27 @@ pub struct TrustDeviceSigningKeyDeleteRes {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct TrustDeviceSigningKeyRotateReq {
+    pub vault_path: String,
+    pub old_device_id: String,
+    pub new_device_label: String,
+    pub passphrase: String,
+    pub now_ms: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TrustDeviceSigningKeyRotateRes {
+    pub old_signing_key: TrustDeviceSigningKeyRes,
+    pub device_id: String,
+    pub label: String,
+    pub fingerprint: String,
+    pub cert_id: String,
+    pub cert_chain_hash: String,
+    pub signing_key: TrustDeviceSigningKeyRes,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TrustProviderAddReq {
     pub vault_path: String,
     pub provider_id: String,
@@ -1318,6 +1339,29 @@ pub fn trust_device_signing_key_delete_rpc(
         Ok(out) => RpcResponse::ok(TrustDeviceSigningKeyDeleteRes {
             deleted: out.deleted,
             signing_key: out.signing_key.map(signing_key_res),
+        }),
+        Err(error) => RpcResponse::err(error),
+    }
+}
+
+pub fn trust_device_signing_key_rotate_rpc(
+    req: TrustDeviceSigningKeyRotateReq,
+) -> RpcResponse<TrustDeviceSigningKeyRotateRes> {
+    match rpc_service::trust_device_signing_key_rotate_service(
+        std::path::Path::new(&req.vault_path),
+        &req.old_device_id,
+        &req.new_device_label,
+        &req.passphrase,
+        req.now_ms,
+    ) {
+        Ok(out) => RpcResponse::ok(TrustDeviceSigningKeyRotateRes {
+            old_signing_key: signing_key_res(out.old_signing_key),
+            device_id: out.device.device_id,
+            label: out.device.label,
+            fingerprint: out.device.fingerprint,
+            cert_id: out.certificate.cert_id,
+            cert_chain_hash: out.certificate.cert_chain_hash,
+            signing_key: signing_key_res(out.signing_key),
         }),
         Err(error) => RpcResponse::err(error),
     }

--- a/apps/desktop/src-tauri/tests/rpc.rs
+++ b/apps/desktop/src-tauri/tests/rpc.rs
@@ -7,30 +7,30 @@ use apps_desktop_tauri::rpc::{
     lineage_query_v2_rpc, lineage_role_grant_rpc, lineage_role_list_rpc, lineage_role_revoke_rpc,
     sync_merge_preview_rpc, sync_pull_rpc, sync_push_rpc, sync_status_rpc, trust_device_enroll_rpc,
     trust_device_enroll_signing_key_rpc, trust_device_list_rpc,
-    trust_device_signing_key_delete_rpc, trust_device_signing_key_status_rpc,
-    trust_device_verify_chain_rpc, trust_identity_complete_rpc, trust_identity_start_rpc,
-    trust_policy_set_tenant_template_rpc, trust_provider_discover_rpc, vault_encryption_enable_rpc,
-    vault_encryption_migrate_rpc, vault_encryption_status_rpc, vault_init_rpc, vault_lock_rpc,
-    vault_lock_status_rpc, vault_open_rpc, vault_recovery_escrow_enable_rpc,
-    vault_recovery_escrow_provider_add_rpc, vault_recovery_escrow_provider_list_rpc,
-    vault_recovery_escrow_restore_rpc, vault_recovery_escrow_rotate_all_rpc,
-    vault_recovery_escrow_rotate_rpc, vault_recovery_escrow_status_rpc,
-    vault_recovery_generate_rpc, vault_recovery_status_rpc, vault_recovery_verify_rpc,
-    vault_unlock_rpc, IngestInboxStartReq, IngestInboxStopReq, JobsListReq, LineageLockAcquireReq,
-    LineageLockAcquireScopeReq, LineageLockReleaseReq, LineageLockStatusReq, LineageOverlayAddReq,
-    LineageOverlayListReq, LineageOverlayRemoveReq, LineagePolicyAddReq, LineagePolicyBindReq,
-    LineagePolicyListReq, LineageQueryReq, LineageQueryV2Req, LineageRoleGrantReq,
-    LineageRoleListReq, LineageRoleRevokeReq, RpcResponse, SyncMergePreviewReq, SyncPullReq,
-    SyncPushReq, SyncStatusReq, TrustDeviceEnrollReq, TrustDeviceEnrollSigningKeyReq,
-    TrustDeviceListReq, TrustDeviceSigningKeyDeleteReq, TrustDeviceSigningKeyStatusReq,
-    TrustDeviceVerifyChainReq, TrustIdentityCompleteReq, TrustIdentityStartReq,
-    TrustPolicySetTenantTemplateReq, TrustProviderDiscoverReq, VaultEncryptionEnableReq,
-    VaultEncryptionMigrateReq, VaultEncryptionStatusReq, VaultInitReq, VaultLockReq,
-    VaultLockStatusReq, VaultOpenReq, VaultRecoveryEscrowEnableReq,
-    VaultRecoveryEscrowProviderAddReq, VaultRecoveryEscrowProviderListReq,
-    VaultRecoveryEscrowRestoreReq, VaultRecoveryEscrowRotateAllReq, VaultRecoveryEscrowRotateReq,
-    VaultRecoveryEscrowStatusReq, VaultRecoveryGenerateReq, VaultRecoveryStatusReq,
-    VaultRecoveryVerifyReq, VaultUnlockReq,
+    trust_device_signing_key_delete_rpc, trust_device_signing_key_rotate_rpc,
+    trust_device_signing_key_status_rpc, trust_device_verify_chain_rpc,
+    trust_identity_complete_rpc, trust_identity_start_rpc, trust_policy_set_tenant_template_rpc,
+    trust_provider_discover_rpc, vault_encryption_enable_rpc, vault_encryption_migrate_rpc,
+    vault_encryption_status_rpc, vault_init_rpc, vault_lock_rpc, vault_lock_status_rpc,
+    vault_open_rpc, vault_recovery_escrow_enable_rpc, vault_recovery_escrow_provider_add_rpc,
+    vault_recovery_escrow_provider_list_rpc, vault_recovery_escrow_restore_rpc,
+    vault_recovery_escrow_rotate_all_rpc, vault_recovery_escrow_rotate_rpc,
+    vault_recovery_escrow_status_rpc, vault_recovery_generate_rpc, vault_recovery_status_rpc,
+    vault_recovery_verify_rpc, vault_unlock_rpc, IngestInboxStartReq, IngestInboxStopReq,
+    JobsListReq, LineageLockAcquireReq, LineageLockAcquireScopeReq, LineageLockReleaseReq,
+    LineageLockStatusReq, LineageOverlayAddReq, LineageOverlayListReq, LineageOverlayRemoveReq,
+    LineagePolicyAddReq, LineagePolicyBindReq, LineagePolicyListReq, LineageQueryReq,
+    LineageQueryV2Req, LineageRoleGrantReq, LineageRoleListReq, LineageRoleRevokeReq, RpcResponse,
+    SyncMergePreviewReq, SyncPullReq, SyncPushReq, SyncStatusReq, TrustDeviceEnrollReq,
+    TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq, TrustDeviceSigningKeyDeleteReq,
+    TrustDeviceSigningKeyRotateReq, TrustDeviceSigningKeyStatusReq, TrustDeviceVerifyChainReq,
+    TrustIdentityCompleteReq, TrustIdentityStartReq, TrustPolicySetTenantTemplateReq,
+    TrustProviderDiscoverReq, VaultEncryptionEnableReq, VaultEncryptionMigrateReq,
+    VaultEncryptionStatusReq, VaultInitReq, VaultLockReq, VaultLockStatusReq, VaultOpenReq,
+    VaultRecoveryEscrowEnableReq, VaultRecoveryEscrowProviderAddReq,
+    VaultRecoveryEscrowProviderListReq, VaultRecoveryEscrowRestoreReq,
+    VaultRecoveryEscrowRotateAllReq, VaultRecoveryEscrowRotateReq, VaultRecoveryEscrowStatusReq,
+    VaultRecoveryGenerateReq, VaultRecoveryStatusReq, VaultRecoveryVerifyReq, VaultUnlockReq,
 };
 use kc_core::app_error::AppError;
 use std::sync::{Mutex, OnceLock};
@@ -250,16 +250,58 @@ fn rpc_trust_device_signing_key_custody_round_trip() {
         RpcResponse::Err { error } => panic!("signing key status failed: {}", error.code),
     }
 
-    match trust_device_signing_key_delete_rpc(TrustDeviceSigningKeyDeleteReq {
+    let rotated = trust_device_signing_key_rotate_rpc(TrustDeviceSigningKeyRotateReq {
+        vault_path: vault_path.clone(),
+        old_device_id: device_id.clone(),
+        new_device_label: "desktop-rotated".to_string(),
+        passphrase: "custody-passphrase".to_string(),
+        now_ms: 5,
+    });
+    let new_device_id = match rotated {
+        RpcResponse::Ok { data } => {
+            assert_eq!(data.label, "desktop-rotated");
+            assert_ne!(data.device_id, device_id);
+            assert_eq!(data.old_signing_key.device_id, device_id);
+            assert_eq!(data.old_signing_key.rotated_at_ms, Some(9));
+            assert_eq!(data.old_signing_key.deleted_at_ms, Some(9));
+            assert_eq!(data.signing_key.device_id, data.device_id);
+            data.device_id
+        }
+        RpcResponse::Err { error } => panic!("signing key rotate failed: {}", error.code),
+    };
+
+    match trust_device_signing_key_status_rpc(TrustDeviceSigningKeyStatusReq {
         vault_path: vault_path.clone(),
         device_id: device_id.clone(),
-        now_ms: 5,
+    }) {
+        RpcResponse::Ok { data } => assert!(data.signing_key.is_none()),
+        RpcResponse::Err { error } => {
+            panic!("old signing key status after rotate failed: {}", error.code)
+        }
+    }
+
+    match trust_device_list_rpc(TrustDeviceListReq {
+        vault_path: vault_path.clone(),
+    }) {
+        RpcResponse::Ok { data } => {
+            assert!(data.devices.iter().any(|d| d.device_id == device_id));
+            assert!(data.devices.iter().any(|d| d.device_id == new_device_id));
+        }
+        RpcResponse::Err { error } => {
+            panic!("trust device list after rotate failed: {}", error.code)
+        }
+    }
+
+    match trust_device_signing_key_delete_rpc(TrustDeviceSigningKeyDeleteReq {
+        vault_path: vault_path.clone(),
+        device_id: new_device_id.clone(),
+        now_ms: 10,
     }) {
         RpcResponse::Ok { data } => {
             assert!(data.deleted);
             assert_eq!(
                 data.signing_key.expect("deleted signing key").device_id,
-                device_id
+                new_device_id
             );
         }
         RpcResponse::Err { error } => panic!("signing key delete failed: {}", error.code),
@@ -267,7 +309,7 @@ fn rpc_trust_device_signing_key_custody_round_trip() {
 
     match trust_device_signing_key_status_rpc(TrustDeviceSigningKeyStatusReq {
         vault_path,
-        device_id,
+        device_id: new_device_id,
     }) {
         RpcResponse::Ok { data } => assert!(data.signing_key.is_none()),
         RpcResponse::Err { error } => {

--- a/apps/desktop/src-tauri/tests/rpc_schema.rs
+++ b/apps/desktop/src-tauri/tests/rpc_schema.rs
@@ -5,8 +5,8 @@ use apps_desktop_tauri::rpc::{
     LineageQueryV2Req, LineageRoleGrantReq, LineageRoleListReq, LineageRoleRevokeReq,
     SearchQueryReq, SyncMergePreviewReq, SyncPullReq, SyncPushReq, SyncStatusReq,
     TrustDeviceEnrollReq, TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq,
-    TrustDeviceSigningKeyDeleteReq, TrustDeviceSigningKeyStatusReq, TrustDeviceVerifyChainReq,
-    TrustIdentityCompleteReq, TrustIdentityStartReq, TrustPolicySetReq,
+    TrustDeviceSigningKeyDeleteReq, TrustDeviceSigningKeyRotateReq, TrustDeviceSigningKeyStatusReq,
+    TrustDeviceVerifyChainReq, TrustIdentityCompleteReq, TrustIdentityStartReq, TrustPolicySetReq,
     TrustPolicySetTenantTemplateReq, TrustProviderAddReq, TrustProviderDisableReq,
     TrustProviderDiscoverReq, TrustProviderListReq, VaultEncryptionEnableReq,
     VaultEncryptionMigrateReq, VaultEncryptionStatusReq, VaultInitReq, VaultLockReq,
@@ -394,6 +394,15 @@ fn rpc_schema_trust_device_requests_validate_shapes() {
     });
     assert!(serde_json::from_value::<TrustDeviceSigningKeyDeleteReq>(signing_key_delete).is_ok());
 
+    let signing_key_rotate = serde_json::json!({
+        "vault_path": "/tmp/vault",
+        "old_device_id": "device-1",
+        "new_device_label": "desktop-rotated",
+        "passphrase": "secret",
+        "now_ms": 106
+    });
+    assert!(serde_json::from_value::<TrustDeviceSigningKeyRotateReq>(signing_key_rotate).is_ok());
+
     let list = serde_json::json!({
         "vault_path": "/tmp/vault"
     });
@@ -409,6 +418,15 @@ fn rpc_schema_trust_device_rejects_unknown_fields() {
         "extra": "nope"
     });
     assert!(serde_json::from_value::<TrustDeviceEnrollReq>(invalid).is_err());
+
+    let invalid_rotate = serde_json::json!({
+        "vault_path": "/tmp/vault",
+        "old_device_id": "device-1",
+        "new_device_label": "desktop-rotated",
+        "passphrase": "secret",
+        "extra": "nope"
+    });
+    assert!(serde_json::from_value::<TrustDeviceSigningKeyRotateReq>(invalid_rotate).is_err());
 }
 
 #[test]

--- a/crates/kc_cli/src/cli.rs
+++ b/crates/kc_cli/src/cli.rs
@@ -295,6 +295,17 @@ pub enum TrustDeviceCmd {
         #[arg(long = "now-ms")]
         now_ms: Option<i64>,
     },
+    SigningKeyRotate {
+        vault_path: String,
+        #[arg(long = "old-device-id")]
+        old_device_id: String,
+        #[arg(long = "new-device-label")]
+        new_device_label: String,
+        #[arg(long = "passphrase-env")]
+        passphrase_env: String,
+        #[arg(long = "now-ms")]
+        now_ms: Option<i64>,
+    },
     List {
         vault_path: String,
     },

--- a/crates/kc_cli/src/commands/trust.rs
+++ b/crates/kc_cli/src/commands/trust.rs
@@ -2,9 +2,10 @@ use kc_core::app_error::{AppError, AppResult};
 use kc_core::rpc_service::{
     trust_device_enroll_service, trust_device_enroll_signing_key_service,
     trust_device_list_service, trust_device_signing_key_delete_service,
-    trust_device_signing_key_status_service, trust_device_verify_chain_service,
-    trust_identity_complete_service, trust_identity_start_service, trust_provider_add_service,
-    trust_provider_disable_service, trust_provider_discover_service, trust_provider_list_service,
+    trust_device_signing_key_rotate_service, trust_device_signing_key_status_service,
+    trust_device_verify_chain_service, trust_identity_complete_service,
+    trust_identity_start_service, trust_provider_add_service, trust_provider_disable_service,
+    trust_provider_discover_service, trust_provider_list_service,
     trust_provider_policy_set_service, trust_provider_policy_set_tenant_template_service,
 };
 use std::path::Path;
@@ -172,6 +173,35 @@ pub fn run_device_signing_key_delete(
         serde_json::to_string_pretty(&serde_json::json!({
             "status": "ok",
             "deleted": out.deleted,
+            "signing_key": out.signing_key
+        }))
+        .unwrap_or_else(|_| "{}".to_string())
+    );
+    Ok(())
+}
+
+pub fn run_device_signing_key_rotate(
+    vault_path: &str,
+    old_device_id: &str,
+    new_device_label: &str,
+    passphrase_env: &str,
+    now_override: Option<i64>,
+) -> AppResult<()> {
+    let passphrase = passphrase_from_env(passphrase_env)?;
+    let out = trust_device_signing_key_rotate_service(
+        Path::new(vault_path),
+        old_device_id,
+        new_device_label,
+        &passphrase,
+        now_override.unwrap_or_else(now_ms),
+    )?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "status": "ok",
+            "old_signing_key": out.old_signing_key,
+            "device": out.device,
+            "certificate": out.certificate,
             "signing_key": out.signing_key
         }))
         .unwrap_or_else(|_| "{}".to_string())

--- a/crates/kc_cli/src/main.rs
+++ b/crates/kc_cli/src/main.rs
@@ -419,6 +419,19 @@ fn main() {
                 } => {
                     commands::trust::run_device_signing_key_delete(&vault_path, &device_id, now_ms)
                 }
+                TrustDeviceCmd::SigningKeyRotate {
+                    vault_path,
+                    old_device_id,
+                    new_device_label,
+                    passphrase_env,
+                    now_ms,
+                } => commands::trust::run_device_signing_key_rotate(
+                    &vault_path,
+                    &old_device_id,
+                    &new_device_label,
+                    &passphrase_env,
+                    now_ms,
+                ),
                 TrustDeviceCmd::List { vault_path } => {
                     commands::trust::run_device_list(&vault_path)
                 }

--- a/crates/kc_cli/tests/trust.rs
+++ b/crates/kc_cli/tests/trust.rs
@@ -212,15 +212,109 @@ fn cli_trust_device_enroll_signing_key_records_custody_metadata() {
         Some(device_id)
     );
 
+    std::env::set_var("KC_TEST_SYNC_KEY_PASSPHRASE", "custody-passphrase");
+    let rotated = run_cli(&[
+        "trust",
+        "device",
+        "signing-key-rotate",
+        &vault_path,
+        "--old-device-id",
+        device_id,
+        "--new-device-label",
+        "desktop-rotated",
+        "--passphrase-env",
+        "KC_TEST_SYNC_KEY_PASSPHRASE",
+        "--now-ms",
+        "33",
+    ]);
+    std::env::remove_var("KC_TEST_SYNC_KEY_PASSPHRASE");
+    assert!(
+        rotated.status.success(),
+        "signing key rotate stderr: {}",
+        String::from_utf8_lossy(&rotated.stderr)
+    );
+    let rotated_json: serde_json::Value =
+        serde_json::from_slice(&rotated.stdout).expect("rotate json");
+    assert_eq!(
+        rotated_json
+            .get("old_signing_key")
+            .and_then(|v| v.get("device_id"))
+            .and_then(|v| v.as_str()),
+        Some(device_id)
+    );
+    assert_eq!(
+        rotated_json
+            .get("old_signing_key")
+            .and_then(|v| v.get("rotated_at_ms"))
+            .and_then(|v| v.as_i64()),
+        Some(37)
+    );
+    let new_device_id = rotated_json
+        .get("device")
+        .and_then(|v| v.get("device_id"))
+        .and_then(|v| v.as_str())
+        .expect("replacement device id");
+    assert_ne!(new_device_id, device_id);
+    assert_eq!(
+        rotated_json
+            .get("signing_key")
+            .and_then(|v| v.get("device_id"))
+            .and_then(|v| v.as_str()),
+        Some(new_device_id)
+    );
+
+    let old_status_after_rotate = run_cli(&[
+        "trust",
+        "device",
+        "signing-key-status",
+        &vault_path,
+        "--device-id",
+        device_id,
+    ]);
+    assert!(
+        old_status_after_rotate.status.success(),
+        "old signing key status after rotate stderr: {}",
+        String::from_utf8_lossy(&old_status_after_rotate.stderr)
+    );
+    let old_status_after_rotate_json: serde_json::Value =
+        serde_json::from_slice(&old_status_after_rotate.stdout).expect("old status json");
+    assert!(old_status_after_rotate_json
+        .get("signing_key")
+        .unwrap()
+        .is_null());
+
+    let listed_after_rotate = run_cli(&["trust", "device", "list", &vault_path]);
+    assert!(
+        listed_after_rotate.status.success(),
+        "list after rotate stderr: {}",
+        String::from_utf8_lossy(&listed_after_rotate.stderr)
+    );
+    let listed_after_rotate_json: serde_json::Value =
+        serde_json::from_slice(&listed_after_rotate.stdout).expect("list after rotate json");
+    let listed_devices = listed_after_rotate_json
+        .get("devices")
+        .and_then(|v| v.as_array())
+        .expect("devices array after rotate");
+    assert!(listed_devices.iter().any(|d| {
+        d.get("device_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| id == device_id)
+    }));
+    assert!(listed_devices.iter().any(|d| {
+        d.get("device_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| id == new_device_id)
+    }));
+
     let deleted = run_cli(&[
         "trust",
         "device",
         "signing-key-delete",
         &vault_path,
         "--device-id",
-        device_id,
+        new_device_id,
         "--now-ms",
-        "33",
+        "38",
     ]);
     assert!(
         deleted.status.success(),
@@ -240,7 +334,7 @@ fn cli_trust_device_enroll_signing_key_records_custody_metadata() {
         "signing-key-status",
         &vault_path,
         "--device-id",
-        device_id,
+        new_device_id,
     ]);
     assert!(
         status_after_delete.status.success(),

--- a/crates/kc_cli/tests/trust.rs
+++ b/crates/kc_cli/tests/trust.rs
@@ -350,6 +350,56 @@ fn cli_trust_device_enroll_signing_key_records_custody_metadata() {
 }
 
 #[test]
+fn cli_trust_device_signing_key_rotate_rejects_missing_old_custody() {
+    let root = tempfile::tempdir().expect("tempdir").keep();
+    vault_init(&root, "demo", 1).expect("vault init");
+    let vault_path = root.to_string_lossy().to_string();
+
+    std::env::set_var(
+        "KC_TEST_SYNC_KEY_ROTATE_MISSING_PASSPHRASE",
+        "custody-passphrase",
+    );
+    let rotate = run_cli(&[
+        "trust",
+        "device",
+        "signing-key-rotate",
+        &vault_path,
+        "--old-device-id",
+        "missing-device",
+        "--new-device-label",
+        "desktop-rotated",
+        "--passphrase-env",
+        "KC_TEST_SYNC_KEY_ROTATE_MISSING_PASSPHRASE",
+        "--now-ms",
+        "50",
+    ]);
+    std::env::remove_var("KC_TEST_SYNC_KEY_ROTATE_MISSING_PASSPHRASE");
+    assert!(!rotate.status.success());
+    assert!(
+        String::from_utf8_lossy(&rotate.stderr).contains("KC_SYNC_SIGNING_KEY_NOT_FOUND"),
+        "rotate missing stderr: {}",
+        String::from_utf8_lossy(&rotate.stderr)
+    );
+
+    let listed = run_cli(&["trust", "device", "list", &vault_path]);
+    assert!(
+        listed.status.success(),
+        "list after failed rotate stderr: {}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+    let listed_json: serde_json::Value =
+        serde_json::from_slice(&listed.stdout).expect("list after failed rotate json");
+    assert_eq!(
+        listed_json
+            .get("devices")
+            .and_then(|v| v.as_array())
+            .expect("devices array")
+            .len(),
+        0
+    );
+}
+
+#[test]
 fn cli_trust_discovery_and_tenant_template_round_trip() {
     let root = tempfile::tempdir().expect("tempdir").keep();
     vault_init(&root, "demo", 1).expect("vault init");

--- a/crates/kc_core/src/rpc_service.rs
+++ b/crates/kc_core/src/rpc_service.rs
@@ -35,7 +35,8 @@ use crate::recovery_escrow_private_kms::{
 };
 use crate::resource_limits::{ingest_single_file_limits, scan_folder_limits};
 use crate::sync_key_custody::{
-    delete_sync_signing_key, store_sync_signing_seed, sync_signing_key_status, SyncSigningKeyStatus,
+    delete_sync_signing_key, rotate_sync_signing_key, store_sync_signing_seed,
+    sync_signing_key_status, SyncSigningKeyStatus,
 };
 use crate::trust::{
     trust_device_init, trust_device_init_with_seed, trust_device_list, trust_device_verify,
@@ -213,6 +214,14 @@ pub struct TrustDeviceEnrollSigningKeyResult {
 pub struct TrustDeviceSigningKeyDeleteResult {
     pub deleted: bool,
     pub signing_key: Option<SyncSigningKeyStatus>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TrustDeviceSigningKeyRotateResult {
+    pub old_signing_key: SyncSigningKeyStatus,
+    pub device: TrustedDeviceRecord,
+    pub certificate: DeviceCertificateRecord,
+    pub signing_key: SyncSigningKeyStatus,
 }
 
 struct SyncSigningSeed([u8; 32]);
@@ -1181,6 +1190,91 @@ pub fn trust_device_signing_key_delete_service(
     let signing_key = delete_sync_signing_key(&conn, device_id, now_ms)?;
     Ok(TrustDeviceSigningKeyDeleteResult {
         deleted: signing_key.is_some(),
+        signing_key,
+    })
+}
+
+pub fn trust_device_signing_key_rotate_service(
+    vault_path: &Path,
+    old_device_id: &str,
+    new_device_label: &str,
+    passphrase: &str,
+    now_ms: i64,
+) -> AppResult<TrustDeviceSigningKeyRotateResult> {
+    ensure_passphrase_not_empty(passphrase)?;
+    let vault = vault_open(vault_path)?;
+    let conn = open_db(&vault_path.join(vault.db.relative_path))?;
+
+    if sync_signing_key_status(&conn, old_device_id)?.is_none() {
+        return Err(AppError::new(
+            "KC_SYNC_SIGNING_KEY_NOT_FOUND",
+            "sync_key_custody",
+            "active sync signing key custody row is required for rotation",
+            false,
+            serde_json::json!({ "device_id": old_device_id }),
+        ));
+    }
+
+    let mut seed = SyncSigningSeed([0u8; 32]);
+    getrandom::fill(&mut seed.0).map_err(|e| {
+        AppError::new(
+            "KC_SYNC_SIGNING_KEY_WRITE_FAILED",
+            "sync_key_custody",
+            "failed generating replacement sync signing key seed",
+            false,
+            serde_json::json!({ "error": e.to_string() }),
+        )
+    })?;
+    let tx = conn.unchecked_transaction().map_err(|e| {
+        AppError::new(
+            "KC_SYNC_SIGNING_KEY_WRITE_FAILED",
+            "sync_key_custody",
+            "failed beginning sync signing key rotation transaction",
+            false,
+            serde_json::json!({ "error": e.to_string(), "device_id": old_device_id }),
+        )
+    })?;
+    let created = trust_device_init_with_seed(
+        &tx,
+        new_device_label,
+        "trust_device_signing_key_rotate",
+        now_ms,
+        &seed.0,
+    )?;
+    let verified = trust_device_verify(
+        &tx,
+        &created.device_id,
+        &created.fingerprint,
+        "trust_device_signing_key_rotate",
+        now_ms + 1,
+    )?;
+    let certificate = trust_device_enroll(&tx, "default", &verified.device_id, now_ms + 2)?;
+    let signing_key =
+        store_sync_signing_seed(&tx, &verified.device_id, &seed.0, passphrase, now_ms + 3)?;
+    let old_signing_key =
+        rotate_sync_signing_key(&tx, old_device_id, now_ms + 4)?.ok_or_else(|| {
+            AppError::new(
+                "KC_SYNC_SIGNING_KEY_NOT_FOUND",
+                "sync_key_custody",
+                "sync signing key custody row disappeared during rotation",
+                false,
+                serde_json::json!({ "device_id": old_device_id }),
+            )
+        })?;
+    tx.commit().map_err(|e| {
+        AppError::new(
+            "KC_SYNC_SIGNING_KEY_WRITE_FAILED",
+            "sync_key_custody",
+            "failed committing sync signing key rotation transaction",
+            false,
+            serde_json::json!({ "error": e.to_string(), "device_id": old_device_id }),
+        )
+    })?;
+
+    Ok(TrustDeviceSigningKeyRotateResult {
+        old_signing_key,
+        device: verified,
+        certificate,
         signing_key,
     })
 }

--- a/crates/kc_core/src/sync_key_custody.rs
+++ b/crates/kc_core/src/sync_key_custody.rs
@@ -360,6 +360,33 @@ pub fn delete_sync_signing_key(
     Ok(Some(existing.status))
 }
 
+pub fn rotate_sync_signing_key(
+    conn: &Connection,
+    device_id: &str,
+    now_ms: i64,
+) -> AppResult<Option<SyncSigningKeyStatus>> {
+    let Some(existing) = active_row(conn, device_id)? else {
+        return Ok(None);
+    };
+    conn.execute(
+        "UPDATE sync_signing_keys
+         SET rotated_at_ms=?1, deleted_at_ms=?1
+         WHERE device_id=?2 AND deleted_at_ms IS NULL",
+        params![now_ms, device_id],
+    )
+    .map_err(|e| {
+        custody_error(
+            "KC_SYNC_SIGNING_KEY_WRITE_FAILED",
+            "failed rotating sync signing key custody row",
+            serde_json::json!({ "error": e.to_string(), "device_id": device_id }),
+        )
+    })?;
+    let mut status = existing.status;
+    status.rotated_at_ms = Some(now_ms);
+    status.deleted_at_ms = Some(now_ms);
+    Ok(Some(status))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,5 +410,31 @@ mod tests {
             .expect("load")
             .expect("key");
         assert_eq!(loaded.to_bytes(), seed);
+    }
+
+    #[test]
+    fn sync_signing_rotation_marks_active_row_retired() {
+        let conn = Connection::open_in_memory().expect("db");
+        apply_migrations(&conn).expect("migrations");
+        assert!(rotate_sync_signing_key(&conn, "missing-device", 20)
+            .expect("missing rotate")
+            .is_none());
+
+        let seed = [7u8; 32];
+        let device =
+            trust_device_init_with_seed(&conn, "fixture", "test", 21, &seed).expect("device");
+        trust_device_verify(&conn, &device.device_id, &device.fingerprint, "test", 22)
+            .expect("verify");
+        store_sync_signing_seed(&conn, &device.device_id, &seed, "passphrase", 23).expect("store");
+
+        let retired = rotate_sync_signing_key(&conn, &device.device_id, 24)
+            .expect("rotate")
+            .expect("retired");
+        assert_eq!(retired.device_id, device.device_id);
+        assert_eq!(retired.rotated_at_ms, Some(24));
+        assert_eq!(retired.deleted_at_ms, Some(24));
+        assert!(sync_signing_key_status(&conn, &device.device_id)
+            .expect("status")
+            .is_none());
     }
 }

--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -61,7 +61,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Compatible Ed25519 sync authorship verification is now wired for v3 heads: incoming heads prefer Ed25519 verification against the trusted device public key and verified certificate chain, with legacy BLAKE3-derived signatures still accepted for compatibility.
 - S3 sync emits Ed25519 author signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it preserves legacy v3 signature emission.
 - Sync head parsing now supports optional `author_signature_alg = "ed25519_sync_head_v1"` as a v3 extension. Declared Ed25519 heads must pass Ed25519 verification and cannot fall back to legacy BLAKE3-derived signatures; unknown declared algorithms fail closed.
-- Local sync signing key custody is now implemented behind explicit trust-device enrollment: schema v12 adds `sync_signing_keys`, private Ed25519 seeds are encrypted with XChaCha20-Poly1305 using the vault unlock passphrase boundary, CLI/desktop surfaces expose status and soft-delete controls, and S3 sync emits `author_signature_alg = "ed25519_sync_head_v1"` only when the custody key is unlocked and matches the verified local author device.
+- Local sync signing key custody is now implemented behind explicit trust-device enrollment: schema v12 adds `sync_signing_keys`, private Ed25519 seeds are encrypted with XChaCha20-Poly1305 using the vault unlock passphrase boundary, CLI/desktop surfaces expose enrollment/status/soft-delete/rotation controls, and S3 sync emits `author_signature_alg = "ed25519_sync_head_v1"` only when the custody key is unlocked and matches the verified local author device.
 - Recovery verification now decrypts `key_blob.enc` with the recovery phrase-derived key, checks the deterministic recovery nonce, rejects empty restored passphrases, and includes regressions for matching-hash forged blobs that cannot decrypt.
 - DB encryption lifecycle tests now pin unsupported mode/KDF rejection, idempotent already-encrypted migration detection, wrong-key failure for encrypted DB migration, and absence of stale `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
 - SQLCipher production state semantics are captured as an approval-gated design note in `docs/21-sqlcipher-state-model-plan-2026-06-19.md`; the documented decision is a future `vault.json` v4 `db_encryption.state` boundary, with no schema or runtime behavior changed in this lane.
@@ -89,7 +89,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Do not promote S3 sync, managed identity, or recovery escrow to production-ready until their current risk items are resolved and verified.
 
 ## Next Recommended Lane
-1. Approve signing-key rotation/recovery semantics, then decide rollout timing for removing the undeclared legacy v3 BLAKE3-derived sync signature fallback.
+1. Implement the read-only sync auth readiness report before any private-key recovery, strict-mode enforcement, or undeclared legacy fallback removal.
 2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
 3. Decide whether non-OCR PDF page-count limits are needed beyond the current PDF byte and OCR page-count guardrails.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.

--- a/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
@@ -20,7 +20,7 @@ Legacy v3 author signatures still prove deterministic formatting, not authorship
 Remote sync heads should be accepted only when authorship is verified against an approved trust chain and a real Ed25519 signature over a versioned canonical sync payload.
 
 ## Required Design Decisions
-- Key custody: implemented for initial local storage/unlock/delete primitives using encrypted vault-local custody with CLI and desktop RPC status/delete surfaces; rotation and backup/recovery policy remain future work.
+- Key custody: implemented for local storage/unlock/delete/rotation primitives using encrypted vault-local custody with CLI and desktop RPC surfaces; recovery/fallback-removal policy is captured in `docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md`.
 - Wire compatibility: `author_signature_alg` is implemented as an optional schema-version-3 extension for read/validation and custody-signed S3 writes.
 - Trust source: decide whether remote author certificates must already exist in the local DB, be carried in the signed snapshot, or be verified through another explicit trust-import flow.
 - Certificate state: define how expiration, revocation, and provider/session status affect sync acceptance.
@@ -32,7 +32,8 @@ Remote sync heads should be accepted only when authorship is verified against an
 3. Done: add compatible runtime support that signs with Ed25519 only when an explicit env-provided signing key matches the verified local author device.
 4. Done: add optional algorithm parsing and strict declared-Ed25519 acceptance semantics.
 5. Done: add initial encrypted local key custody, status/delete surfaces, and declared-algorithm writer emission when the custody key is unlocked.
-6. Remaining: approve rotation/recovery semantics, remote trust import, and the point at which undeclared legacy BLAKE3-derived author signatures become hard failures.
+6. Done: add explicit runtime rotation that enrolls a replacement signing device and retires old local custody while preserving old public trust records.
+7. Remaining: implement read-only sync auth readiness reporting, then separately approve remote trust import and the point at which undeclared legacy BLAKE3-derived author signatures become hard failures.
 
 ## Implementation Checkpoint
 - Added a private `kc_core::sync_auth` helper module for future Ed25519 signed-head work.
@@ -44,6 +45,8 @@ Remote sync heads should be accepted only when authorship is verified against an
 - Wired optional `author_signature_alg` parsing for v3 heads; declared `ed25519_sync_head_v1` heads require Ed25519 success, and unknown algorithms fail closed.
 - Added schema v12 `sync_signing_keys` custody storage and CLI/core-service enrollment for encrypted local signing seeds.
 - Added CLI/core-service/desktop RPC status and soft-delete surfaces for encrypted local signing-key custody.
+- Added CLI/core-service/desktop RPC rotation surfaces that enroll a replacement signing device and mark the old local custody row rotated/deleted.
+- Added the rotation/recovery/fallback-removal decision record as `docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md`.
 - S3 sync emits declared Ed25519 heads when the custody key is available through the vault unlock/passphrase boundary.
 - No cloud behavior, remote trust bootstrapping, background sync, or legacy fallback removal changed in this checkpoint.
 
@@ -59,6 +62,6 @@ Remote sync heads should be accepted only when authorship is verified against an
 
 ## Approval Gates
 - Do not remove the legacy v3 signature fallback, change sync head schema, or change vault storage without explicit design approval.
-- Do not extend private-key persistence beyond the initial encrypted local custody model without explicit rotation/recovery design approval.
+- Do not extend private-key persistence beyond the encrypted local custody and replacement-device rotation model without explicit recovery design approval.
 - Do not introduce background sync, automatic cloud sync, or new remote trust bootstrapping in this lane.
 - Do not mark S3 sync or managed identity production-ready until signed-head acceptance, recovery, and resource-limit gates are green.

--- a/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
+++ b/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
@@ -19,7 +19,7 @@ Adopt an explicit algorithm-signaled sync head transition before removing the le
 - Prefer adding `author_signature_alg` to the sync head metadata over silently changing v3 semantics.
 - Keep existing v1/v2/v3 heads readable during the transition.
 - Treat legacy BLAKE3-derived v3 signatures as compatibility-only and never as production-grade signed sync.
-- Do not extend sync signing private-key persistence beyond the approved local encrypted custody model until rotation, recovery, and fallback-removal behavior is explicitly approved.
+- Do not extend sync signing private-key persistence beyond the approved local encrypted custody and replacement-device rotation model until recovery and fallback-removal behavior is explicitly approved.
 
 ## Recommended Key Custody Direction
 Use vault-local encrypted key custody rather than environment variables for production signing.
@@ -30,7 +30,8 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - Done: keep the trusted device public key as the verification anchor.
 - Done: require unlock/passphrase availability before signing declared sync heads; locked custody fails closed rather than silently downgrading.
 - Done: expose explicit status and soft-delete surfaces for local encrypted signing-key custody.
-- Support explicit rotation by enrolling a new device key/certificate and marking old signing material retired.
+- Done: support explicit runtime rotation by enrolling a new signing device/certificate and marking old local signing material retired.
+- Recovery/fallback-removal policy is captured in `docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md`.
 - Done: support explicit deletion by retiring encrypted private-key material without deleting historical public trust records needed for verification.
 
 ## Schema and Compatibility Contract
@@ -56,6 +57,7 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - Schema v12 adds `sync_signing_keys` for encrypted local custody metadata and encrypted signing seeds.
 - `trust device enroll-signing-key` creates a verified trusted device, enrolls its certificate, and stores the encrypted matching signing seed without printing secret material.
 - `trust device signing-key-status` and `trust device signing-key-delete` expose custody metadata and explicit local soft-delete without printing secret material; desktop RPC mirrors those status/delete surfaces.
+- `trust device signing-key-rotate` creates a replacement signing device and certificate, stores the new encrypted seed, then marks the old local custody row rotated/deleted while leaving old public trust records readable.
 - S3 sync uses an unlocked custody key to emit declared Ed25519 heads; if no custody key exists, compatibility behavior is preserved.
 
 ## Non-Goals
@@ -68,9 +70,12 @@ Use vault-local encrypted key custody rather than environment variables for prod
 
 ## Approval Gates
 - Changing writer behavior beyond custody-signed S3 heads requires explicit approval.
-- Extending private signing-key persistence to rotation, backup/recovery, or remote custody requires explicit approval and tests.
+- Extending private signing-key persistence to backup/recovery or remote custody requires explicit approval and tests.
 - Removing the legacy fallback requires explicit rollout approval and compatibility evidence for existing heads.
 - Any vault metadata/schema change requires fixtures, downgrade/rollback expectations, and no private-document ingestion.
+
+## Next Safe Lane
+Implement a read-only sync auth readiness report before any private-key recovery, schema migration, strict-mode enforcement, or undeclared legacy fallback removal.
 
 ## Verification Expectations for the Next Code Lane
 - `cargo fmt --all -- --check`
@@ -83,4 +88,4 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - `node scripts/dependency-watch.mjs`
 
 ## Done Criteria
-This lane is done when encrypted local custody, custody-signed declared S3 heads, and compatibility fallback preservation are verified, with rotation/recovery and undeclared legacy fallback removal still approval-gated.
+This lane is done when encrypted local custody, custody-signed declared S3 heads, replacement-device rotation, and compatibility fallback preservation are verified, with recovery and undeclared legacy fallback removal still approval-gated.

--- a/knowledgecore-docpack/docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md
@@ -1,0 +1,72 @@
+# Sync Signing Key Rotation, Recovery, and Fallback Plan - 2026-06-19
+
+## Purpose
+Define the approval gate and current implementation boundary for moving encrypted sync signing key custody from initial local enrollment/status/delete into replacement-device rotation, recovery policy, and eventual legacy fallback removal without changing vault formats, weakening crypto, introducing cloud custody, or breaking existing sync heads by accident.
+
+## Verified Current State
+- Schema v12 `sync_signing_keys` stores one active encrypted signing seed per trusted device id.
+- Signing seeds are encrypted with XChaCha20-Poly1305 using a key derived from the vault unlock passphrase boundary.
+- `trust device enroll-signing-key` creates a verified trusted device, enrolls its certificate, and stores the encrypted matching Ed25519 seed.
+- CLI and desktop RPC expose custody status, soft-delete, and replacement-device rotation controls without returning secret material.
+- `trust device signing-key-rotate` and matching desktop RPC rotation create a replacement signing device/certificate, store the new encrypted local seed, and mark the old local custody row rotated/deleted.
+- Custody-signed S3 sync heads emit `author_signature_alg = "ed25519_sync_head_v1"`.
+- Undeclared v3 sync heads still accept the legacy BLAKE3-derived compatibility signature.
+- No remote private-key custody, background sync, cloud sync expansion, or fallback removal is implemented.
+
+## Rotation Decision
+Rotation should create a new authoring identity rather than mutate private key material in place.
+
+- Done: generate a fresh Ed25519 signing seed through the same explicit local enrollment flow.
+- Done: create a new trusted device id and device certificate for the rotated authoring key.
+- Done: store the new encrypted seed as a new active `sync_signing_keys` row.
+- Done: mark the old encrypted seed row with `rotated_at_ms` and `deleted_at_ms` only after the replacement key is enrolled, verified, and stored.
+- Done: keep historical trusted device public keys and certificates readable so old declared heads remain verifiable.
+- Done: do not overwrite `seed_ciphertext`, `seed_nonce`, `kdf_alg`, or public-key metadata for an existing active row.
+
+## Recovery Decision
+Recovery should be local re-enrollment, not private signing-key backup.
+
+- Do not include sync signing private seeds in export bundles, recovery bundles, recovery escrow descriptors, logs, or docs.
+- If local signing custody is lost, re-enroll a new local signing device after restoring/opening the vault.
+- Preserve old public trust records for historical verification, but treat lost private signing seeds as unrecoverable.
+- Recovery UX should say that local signing authority was re-created, not restored from backup.
+- Any future private-key backup or remote custody design requires a separate threat model, secret-handling design, fixtures, and explicit approval.
+
+## Fallback Removal Decision
+Legacy undeclared v3 signatures can be removed only after compatibility evidence proves existing heads are not stranded.
+
+- First add read-only telemetry/reporting that classifies sync heads as declared Ed25519, undeclared Ed25519-compatible, or undeclared legacy fallback.
+- Then add a user-visible readiness command/report that lists targets still depending on undeclared legacy fallback.
+- Only after that evidence exists, add a separate opt-in enforcement flag or schema-version transition plan.
+- Final removal must fail undeclared legacy fallback heads with a deterministic sync-auth error and clear remediation guidance.
+
+## Safest Implementation Sequence
+1. Done: add explicit rotation command/RPC that enrolls a new signing device and soft-deletes the old custody row only after the new key verifies.
+2. Add a read-only sync auth readiness report for local sync targets; no writes, no migrations, no cloud behavior changes.
+3. Add UI/CLI copy for local re-enrollment recovery when custody is missing or deleted.
+4. Add compatibility fixtures for existing undeclared v3 heads, declared Ed25519 heads, and fallback-removal failure cases.
+5. Add opt-in strict mode for rejecting undeclared legacy fallback before making it default.
+
+## Non-Goals
+- No private signing-key export.
+- No recovery escrow of sync signing seeds.
+- No remote/cloud signing-key custody.
+- No background sync.
+- No automatic trust import.
+- No immediate legacy fallback removal.
+- No schema v13 migration in this design checkpoint.
+
+## Required Tests Before Runtime Changes
+- Done: rotation creates a new trusted device and leaves old public trust records readable.
+- Done: rotation rejects missing active old custody before creating replacement material.
+- Current implementation wraps replacement device creation, certificate enrollment, new custody storage, and old custody retirement in one transaction so late failures do not commit partial rotation state.
+- Deleted/lost custody produces clear locked/missing-key behavior without silently downgrading declared-head signing.
+- Recovery re-enrollment can author a new declared Ed25519 head without requiring old private seed material.
+- Fallback-removal strict mode rejects undeclared legacy signatures while preserving declared Ed25519 acceptance.
+- Fixtures prove old declared heads remain verifiable after old private custody is deleted.
+
+## Approval Gates
+- Runtime rotation is implemented only as replacement-device local custody rotation; changing it to in-place mutation requires explicit approval.
+- Any schema migration requires migration tests, rollback/downgrade expectations, and fixture updates.
+- Any private signing-key backup, escrow, export, or remote custody requires a separate threat model and explicit approval.
+- Legacy fallback removal requires compatibility evidence and explicit rollout approval.


### PR DESCRIPTION
## Summary
- Adds replacement-device sync signing-key rotation for encrypted local custody.
- Rotation validates the old active custody row, creates a new trusted signing device/certificate/key inside a transaction, stores the new encrypted seed, and marks the old custody row rotated/deleted.
- Exposes rotation through CLI and desktop RPC/Tauri commands.
- Extends CLI, desktop RPC, RPC schema, and custody unit coverage for rotation and old public trust record preservation.
- Adds/updates docs for the rotation/recovery/fallback boundary.

## Boundaries
- No private signing-key backup, escrow, export, or remote custody.
- No schema v13 migration.
- No background/cloud sync behavior changes.
- No undeclared legacy fallback removal or strict-mode enforcement.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p kc_cli trust`
- `cargo test -p apps_desktop_tauri rpc_trust_device_signing_key_custody_round_trip`
- `cargo test -p apps_desktop_tauri rpc_schema`
- `cargo test -p kc_core sync_key_custody`
- `cargo test -p kc_core --test trust_identity`
- `cargo test --workspace --exclude apps_desktop_tauri`
- `cargo test -p apps_desktop_tauri`
- `node scripts/audit-rust.mjs`
- `node scripts/dependency-watch.mjs`