### PR TITLE
feat: add sync auth readiness report

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -283,6 +283,13 @@ pub fn sync_status(req: rpc::SyncStatusReq) -> rpc::RpcResponse<rpc::SyncStatusR
 }
 
 #[tauri::command]
+pub fn sync_auth_readiness(
+    req: rpc::SyncAuthReadinessReq,
+) -> rpc::RpcResponse<rpc::SyncAuthReadinessRes> {
+    rpc::sync_auth_readiness_rpc(req)
+}
+
+#[tauri::command]
 pub fn sync_push(req: rpc::SyncPushReq) -> rpc::RpcResponse<rpc::SyncPushRes> {
     rpc::sync_push_rpc(req)
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -48,6 +48,7 @@ fn main() {
         commands::events_list,
         commands::jobs_list,
         commands::sync_status,
+        commands::sync_auth_readiness,
         commands::sync_push,
         commands::sync_pull,
         commands::sync_merge_preview,

--- a/apps/desktop/src-tauri/src/rpc.rs
+++ b/apps/desktop/src-tauri/src/rpc.rs
@@ -771,6 +771,26 @@ pub struct SyncStatusRes {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct SyncAuthReadinessReq {
+    pub vault_path: String,
+    pub target_path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncAuthReadinessRes {
+    pub report_version: i64,
+    pub target_path: String,
+    pub classification: String,
+    pub strict_ready: bool,
+    pub depends_on_legacy_fallback: bool,
+    pub remediation: Option<String>,
+    pub remote_head: Option<SyncHeadRes>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SyncPushReq {
     pub vault_path: String,
     pub target_path: String,
@@ -1905,6 +1925,47 @@ pub fn sync_status_rpc(req: SyncStatusReq) -> RpcResponse<SyncStatusRes> {
             remote_head: status.remote_head.map(map_sync_head),
             seen_remote_snapshot_id: status.seen_remote_snapshot_id,
             last_applied_manifest_hash: status.last_applied_manifest_hash,
+        }),
+        Err(error) => RpcResponse::err(error),
+    }
+}
+
+fn sync_auth_readiness_classification_name(
+    classification: kc_core::sync::SyncAuthReadinessClassification,
+) -> String {
+    match classification {
+        kc_core::sync::SyncAuthReadinessClassification::NoRemoteHead => "no_remote_head",
+        kc_core::sync::SyncAuthReadinessClassification::LegacySchema => "legacy_schema",
+        kc_core::sync::SyncAuthReadinessClassification::DeclaredEd25519 => "declared_ed25519",
+        kc_core::sync::SyncAuthReadinessClassification::UndeclaredEd25519Compatible => {
+            "undeclared_ed25519_compatible"
+        }
+        kc_core::sync::SyncAuthReadinessClassification::UndeclaredLegacyFallback => {
+            "undeclared_legacy_fallback"
+        }
+        kc_core::sync::SyncAuthReadinessClassification::UnsupportedDeclaredAlgorithm => {
+            "unsupported_declared_algorithm"
+        }
+        kc_core::sync::SyncAuthReadinessClassification::Invalid => "invalid",
+    }
+    .to_string()
+}
+
+pub fn sync_auth_readiness_rpc(req: SyncAuthReadinessReq) -> RpcResponse<SyncAuthReadinessRes> {
+    match rpc_service::sync_auth_readiness_service(
+        std::path::Path::new(&req.vault_path),
+        &req.target_path,
+    ) {
+        Ok(report) => RpcResponse::ok(SyncAuthReadinessRes {
+            report_version: report.report_version,
+            target_path: report.target_path,
+            classification: sync_auth_readiness_classification_name(report.classification),
+            strict_ready: report.strict_ready,
+            depends_on_legacy_fallback: report.depends_on_legacy_fallback,
+            remediation: report.remediation,
+            remote_head: report.remote_head.map(map_sync_head),
+            error_code: report.error_code,
+            error_message: report.error_message,
         }),
         Err(error) => RpcResponse::err(error),
     }

--- a/apps/desktop/src-tauri/tests/rpc.rs
+++ b/apps/desktop/src-tauri/tests/rpc.rs
@@ -5,8 +5,8 @@ use apps_desktop_tauri::rpc::{
     lineage_overlay_add_rpc, lineage_overlay_list_rpc, lineage_overlay_remove_rpc,
     lineage_policy_add_rpc, lineage_policy_bind_rpc, lineage_policy_list_rpc, lineage_query_rpc,
     lineage_query_v2_rpc, lineage_role_grant_rpc, lineage_role_list_rpc, lineage_role_revoke_rpc,
-    sync_merge_preview_rpc, sync_pull_rpc, sync_push_rpc, sync_status_rpc, trust_device_enroll_rpc,
-    trust_device_enroll_signing_key_rpc, trust_device_list_rpc,
+    sync_auth_readiness_rpc, sync_merge_preview_rpc, sync_pull_rpc, sync_push_rpc, sync_status_rpc,
+    trust_device_enroll_rpc, trust_device_enroll_signing_key_rpc, trust_device_list_rpc,
     trust_device_signing_key_delete_rpc, trust_device_signing_key_rotate_rpc,
     trust_device_signing_key_status_rpc, trust_device_verify_chain_rpc,
     trust_identity_complete_rpc, trust_identity_start_rpc, trust_policy_set_tenant_template_rpc,
@@ -21,16 +21,17 @@ use apps_desktop_tauri::rpc::{
     LineageLockStatusReq, LineageOverlayAddReq, LineageOverlayListReq, LineageOverlayRemoveReq,
     LineagePolicyAddReq, LineagePolicyBindReq, LineagePolicyListReq, LineageQueryReq,
     LineageQueryV2Req, LineageRoleGrantReq, LineageRoleListReq, LineageRoleRevokeReq, RpcResponse,
-    SyncMergePreviewReq, SyncPullReq, SyncPushReq, SyncStatusReq, TrustDeviceEnrollReq,
-    TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq, TrustDeviceSigningKeyDeleteReq,
-    TrustDeviceSigningKeyRotateReq, TrustDeviceSigningKeyStatusReq, TrustDeviceVerifyChainReq,
-    TrustIdentityCompleteReq, TrustIdentityStartReq, TrustPolicySetTenantTemplateReq,
-    TrustProviderDiscoverReq, VaultEncryptionEnableReq, VaultEncryptionMigrateReq,
-    VaultEncryptionStatusReq, VaultInitReq, VaultLockReq, VaultLockStatusReq, VaultOpenReq,
-    VaultRecoveryEscrowEnableReq, VaultRecoveryEscrowProviderAddReq,
-    VaultRecoveryEscrowProviderListReq, VaultRecoveryEscrowRestoreReq,
-    VaultRecoveryEscrowRotateAllReq, VaultRecoveryEscrowRotateReq, VaultRecoveryEscrowStatusReq,
-    VaultRecoveryGenerateReq, VaultRecoveryStatusReq, VaultRecoveryVerifyReq, VaultUnlockReq,
+    SyncAuthReadinessReq, SyncMergePreviewReq, SyncPullReq, SyncPushReq, SyncStatusReq,
+    TrustDeviceEnrollReq, TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq,
+    TrustDeviceSigningKeyDeleteReq, TrustDeviceSigningKeyRotateReq, TrustDeviceSigningKeyStatusReq,
+    TrustDeviceVerifyChainReq, TrustIdentityCompleteReq, TrustIdentityStartReq,
+    TrustPolicySetTenantTemplateReq, TrustProviderDiscoverReq, VaultEncryptionEnableReq,
+    VaultEncryptionMigrateReq, VaultEncryptionStatusReq, VaultInitReq, VaultLockReq,
+    VaultLockStatusReq, VaultOpenReq, VaultRecoveryEscrowEnableReq,
+    VaultRecoveryEscrowProviderAddReq, VaultRecoveryEscrowProviderListReq,
+    VaultRecoveryEscrowRestoreReq, VaultRecoveryEscrowRotateAllReq, VaultRecoveryEscrowRotateReq,
+    VaultRecoveryEscrowStatusReq, VaultRecoveryGenerateReq, VaultRecoveryStatusReq,
+    VaultRecoveryVerifyReq, VaultUnlockReq,
 };
 use kc_core::app_error::AppError;
 use std::sync::{Mutex, OnceLock};
@@ -670,6 +671,20 @@ fn rpc_sync_status_and_push() {
         RpcResponse::Err { error } => panic!("sync status failed: {}", error.code),
     }
 
+    let readiness_before = sync_auth_readiness_rpc(SyncAuthReadinessReq {
+        vault_path: root.to_string_lossy().to_string(),
+        target_path: sync_target.to_string_lossy().to_string(),
+    });
+    match readiness_before {
+        RpcResponse::Ok { data } => {
+            assert_eq!(data.classification, "no_remote_head");
+            assert!(data.strict_ready);
+            assert!(!data.depends_on_legacy_fallback);
+            assert!(data.remote_head.is_none());
+        }
+        RpcResponse::Err { error } => panic!("sync auth readiness failed: {}", error.code),
+    }
+
     let pushed = sync_push_rpc(SyncPushReq {
         vault_path: root.to_string_lossy().to_string(),
         target_path: sync_target.to_string_lossy().to_string(),
@@ -678,6 +693,20 @@ fn rpc_sync_status_and_push() {
     match pushed {
         RpcResponse::Ok { data } => assert!(!data.snapshot_id.is_empty()),
         RpcResponse::Err { error } => panic!("sync push failed: {}", error.code),
+    }
+
+    let readiness_after = sync_auth_readiness_rpc(SyncAuthReadinessReq {
+        vault_path: root.to_string_lossy().to_string(),
+        target_path: sync_target.to_string_lossy().to_string(),
+    });
+    match readiness_after {
+        RpcResponse::Ok { data } => {
+            assert_eq!(data.classification, "legacy_schema");
+            assert!(!data.strict_ready);
+            assert!(data.depends_on_legacy_fallback);
+            assert!(data.remote_head.is_some());
+        }
+        RpcResponse::Err { error } => panic!("sync auth readiness failed: {}", error.code),
     }
 }
 

--- a/apps/desktop/src-tauri/tests/rpc_schema.rs
+++ b/apps/desktop/src-tauri/tests/rpc_schema.rs
@@ -3,8 +3,8 @@ use apps_desktop_tauri::rpc::{
     LineageLockStatusReq, LineageOverlayAddReq, LineageOverlayListReq, LineageOverlayRemoveReq,
     LineagePolicyAddReq, LineagePolicyBindReq, LineagePolicyListReq, LineageQueryReq,
     LineageQueryV2Req, LineageRoleGrantReq, LineageRoleListReq, LineageRoleRevokeReq,
-    SearchQueryReq, SyncMergePreviewReq, SyncPullReq, SyncPushReq, SyncStatusReq,
-    TrustDeviceEnrollReq, TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq,
+    SearchQueryReq, SyncAuthReadinessReq, SyncMergePreviewReq, SyncPullReq, SyncPushReq,
+    SyncStatusReq, TrustDeviceEnrollReq, TrustDeviceEnrollSigningKeyReq, TrustDeviceListReq,
     TrustDeviceSigningKeyDeleteReq, TrustDeviceSigningKeyRotateReq, TrustDeviceSigningKeyStatusReq,
     TrustDeviceVerifyChainReq, TrustIdentityCompleteReq, TrustIdentityStartReq, TrustPolicySetReq,
     TrustPolicySetTenantTemplateReq, TrustProviderAddReq, TrustProviderDisableReq,
@@ -225,6 +225,13 @@ fn rpc_schema_sync_rejects_unknown_fields() {
         "extra": "nope"
     });
     assert!(serde_json::from_value::<SyncStatusReq>(invalid_status).is_err());
+
+    let invalid_readiness = serde_json::json!({
+        "vault_path": "/tmp/vault",
+        "target_path": "/tmp/target",
+        "extra": "nope"
+    });
+    assert!(serde_json::from_value::<SyncAuthReadinessReq>(invalid_readiness).is_err());
 }
 
 #[test]
@@ -234,6 +241,12 @@ fn rpc_schema_sync_accepts_uri_targets() {
         "target_path": "s3://demo-bucket/kc"
     });
     assert!(serde_json::from_value::<SyncStatusReq>(status).is_ok());
+
+    let readiness = serde_json::json!({
+        "vault_path": "/tmp/vault",
+        "target_path": "s3://demo-bucket/kc"
+    });
+    assert!(serde_json::from_value::<SyncAuthReadinessReq>(readiness).is_ok());
 
     let push = serde_json::json!({
         "vault_path": "/tmp/vault",

--- a/crates/kc_cli/src/cli.rs
+++ b/crates/kc_cli/src/cli.rs
@@ -420,6 +420,10 @@ pub enum SyncCmd {
         vault_path: String,
         target_path: String,
     },
+    AuthReadiness {
+        vault_path: String,
+        target_path: String,
+    },
     Push {
         vault_path: String,
         target_path: String,

--- a/crates/kc_cli/src/commands/sync.rs
+++ b/crates/kc_cli/src/commands/sync.rs
@@ -1,8 +1,8 @@
 use kc_core::app_error::AppResult;
 use kc_core::db::open_db;
 use kc_core::sync::{
-    sync_merge_preview_target_with_policy, sync_pull_target_with_mode, sync_push_target,
-    sync_status_target,
+    sync_auth_readiness_target, sync_merge_preview_target_with_policy, sync_pull_target_with_mode,
+    sync_push_target, sync_status_target,
 };
 use kc_core::vault::vault_open;
 use std::path::Path;
@@ -14,6 +14,17 @@ pub fn run_status(vault_path: &str, target_path: &str) -> AppResult<()> {
     println!(
         "{}",
         serde_json::to_string_pretty(&status).unwrap_or_else(|_| "{}".to_string())
+    );
+    Ok(())
+}
+
+pub fn run_auth_readiness(vault_path: &str, target_path: &str) -> AppResult<()> {
+    let vault = vault_open(Path::new(vault_path))?;
+    let conn = open_db(&Path::new(vault_path).join(vault.db.relative_path))?;
+    let report = sync_auth_readiness_target(&conn, target_path)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_string())
     );
     Ok(())
 }

--- a/crates/kc_cli/src/main.rs
+++ b/crates/kc_cli/src/main.rs
@@ -221,6 +221,10 @@ fn main() {
                 vault_path,
                 target_path,
             } => commands::sync::run_status(&vault_path, &target_path),
+            SyncCmd::AuthReadiness {
+                vault_path,
+                target_path,
+            } => commands::sync::run_auth_readiness(&vault_path, &target_path),
             SyncCmd::Push {
                 vault_path,
                 target_path,

--- a/crates/kc_cli/tests/sync.rs
+++ b/crates/kc_cli/tests/sync.rs
@@ -78,6 +78,39 @@ fn cli_sync_push_and_status_work() {
     );
     let stdout = String::from_utf8(status.stdout).expect("utf8 status");
     assert!(stdout.contains("\"remote_head\""));
+
+    let readiness = Command::new(bin)
+        .args([
+            "sync",
+            "auth-readiness",
+            vault_root.to_string_lossy().as_ref(),
+            sync_target.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("run sync auth-readiness");
+    assert!(
+        readiness.status.success(),
+        "auth readiness stderr: {}",
+        String::from_utf8_lossy(&readiness.stderr)
+    );
+    let readiness_json: serde_json::Value =
+        serde_json::from_slice(&readiness.stdout).expect("auth readiness json");
+    assert_eq!(
+        readiness_json
+            .get("classification")
+            .and_then(|v| v.as_str()),
+        Some("legacy_schema")
+    );
+    assert_eq!(
+        readiness_json
+            .get("depends_on_legacy_fallback")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        readiness_json.get("strict_ready").and_then(|v| v.as_bool()),
+        Some(false)
+    );
 }
 
 #[test]

--- a/crates/kc_core/src/rpc_service.rs
+++ b/crates/kc_core/src/rpc_service.rs
@@ -1037,6 +1037,15 @@ pub fn sync_status_service(
     crate::sync::sync_status_target(&conn, target_uri)
 }
 
+pub fn sync_auth_readiness_service(
+    vault_path: &Path,
+    target_uri: &str,
+) -> AppResult<crate::sync::SyncAuthReadinessReportV1> {
+    let vault = vault_open(vault_path)?;
+    let conn = open_db(&vault_path.join(vault.db.relative_path))?;
+    crate::sync::sync_auth_readiness_target(&conn, target_uri)
+}
+
 pub fn sync_push_service(
     vault_path: &Path,
     target_uri: &str,

--- a/crates/kc_core/src/sync.rs
+++ b/crates/kc_core/src/sync.rs
@@ -81,6 +81,31 @@ pub struct SyncStatusV1 {
     pub last_applied_manifest_hash: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncAuthReadinessClassification {
+    NoRemoteHead,
+    LegacySchema,
+    DeclaredEd25519,
+    UndeclaredEd25519Compatible,
+    UndeclaredLegacyFallback,
+    UnsupportedDeclaredAlgorithm,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncAuthReadinessReportV1 {
+    pub report_version: i64,
+    pub target_path: String,
+    pub classification: SyncAuthReadinessClassification,
+    pub strict_ready: bool,
+    pub depends_on_legacy_fallback: bool,
+    pub remediation: Option<String>,
+    pub remote_head: Option<SyncHeadV1>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncPushResultV1 {
     pub snapshot_id: String,
@@ -1456,6 +1481,178 @@ pub fn sync_status_target(conn: &Connection, target_uri: &str) -> AppResult<Sync
     })
 }
 
+fn classify_sync_auth_readiness(
+    conn: &Connection,
+    target_path: String,
+    remote_head: Option<SyncHeadV1>,
+) -> AppResult<SyncAuthReadinessReportV1> {
+    let Some(head) = remote_head else {
+        return Ok(SyncAuthReadinessReportV1 {
+            report_version: 1,
+            target_path,
+            classification: SyncAuthReadinessClassification::NoRemoteHead,
+            strict_ready: true,
+            depends_on_legacy_fallback: false,
+            remediation: None,
+            remote_head: None,
+            error_code: None,
+            error_message: None,
+        });
+    };
+
+    if head.schema_version < 3 {
+        return Ok(SyncAuthReadinessReportV1 {
+            report_version: 1,
+            target_path,
+            classification: SyncAuthReadinessClassification::LegacySchema,
+            strict_ready: false,
+            depends_on_legacy_fallback: true,
+            remediation: Some(
+                "push a new custody-signed schema v3 head before enabling strict sync auth"
+                    .to_string(),
+            ),
+            remote_head: Some(head),
+            error_code: None,
+            error_message: None,
+        });
+    }
+
+    let signature_alg = head
+        .author_signature_alg
+        .as_deref()
+        .map(str::trim)
+        .filter(|alg| !alg.is_empty());
+    match signature_alg {
+        Some(SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1) => {
+            return match verify_sync_head_author_signature_v1(conn, &head) {
+                Ok(()) => Ok(SyncAuthReadinessReportV1 {
+                    report_version: 1,
+                    target_path,
+                    classification: SyncAuthReadinessClassification::DeclaredEd25519,
+                    strict_ready: true,
+                    depends_on_legacy_fallback: false,
+                    remediation: None,
+                    remote_head: Some(head),
+                    error_code: None,
+                    error_message: None,
+                }),
+                Err(error) => Ok(SyncAuthReadinessReportV1 {
+                    report_version: 1,
+                    target_path,
+                    classification: SyncAuthReadinessClassification::Invalid,
+                    strict_ready: false,
+                    depends_on_legacy_fallback: false,
+                    remediation: Some(
+                        "repair or replace the declared Ed25519 sync head before strict sync auth"
+                            .to_string(),
+                    ),
+                    remote_head: Some(head),
+                    error_code: Some(error.code),
+                    error_message: Some(error.message),
+                }),
+            };
+        }
+        Some(actual) => {
+            return Ok(SyncAuthReadinessReportV1 {
+                report_version: 1,
+                target_path,
+                classification: SyncAuthReadinessClassification::UnsupportedDeclaredAlgorithm,
+                strict_ready: false,
+                depends_on_legacy_fallback: false,
+                remediation: Some(
+                    "replace sync head with a supported declared Ed25519 head".to_string(),
+                ),
+                remote_head: Some(head.clone()),
+                error_code: Some("KC_TRUST_SIGNATURE_INVALID".to_string()),
+                error_message: Some(format!("unsupported author_signature_alg: {}", actual)),
+            });
+        }
+        None => {}
+    }
+
+    let legacy_match = legacy_match_for_head(&head)?;
+    let ed25519_compatible = verify_sync_head_author_signature_v1(conn, &head).is_ok();
+    let (classification, depends_on_legacy_fallback, remediation) = if ed25519_compatible {
+        (
+            SyncAuthReadinessClassification::UndeclaredEd25519Compatible,
+            false,
+            Some(
+                "republish the head with author_signature_alg before strict sync auth".to_string(),
+            ),
+        )
+    } else if legacy_match {
+        (
+            SyncAuthReadinessClassification::UndeclaredLegacyFallback,
+            true,
+            Some(
+                "republish with encrypted custody so the head declares Ed25519 authorship"
+                    .to_string(),
+            ),
+        )
+    } else {
+        (
+            SyncAuthReadinessClassification::Invalid,
+            false,
+            Some("repair or replace the invalid sync head before strict sync auth".to_string()),
+        )
+    };
+
+    Ok(SyncAuthReadinessReportV1 {
+        report_version: 1,
+        target_path,
+        classification,
+        strict_ready: false,
+        depends_on_legacy_fallback,
+        remediation,
+        remote_head: Some(head),
+        error_code: None,
+        error_message: None,
+    })
+}
+
+fn legacy_match_for_head(head: &SyncHeadV1) -> AppResult<bool> {
+    let (
+        Some(author_device_id),
+        Some(author_fingerprint),
+        Some(author_signature),
+        Some(author_cert_id),
+        Some(author_chain_hash),
+    ) = (
+        head.author_device_id.as_deref(),
+        head.author_fingerprint.as_deref(),
+        head.author_signature.as_deref(),
+        head.author_cert_id.as_deref(),
+        head.author_chain_hash.as_deref(),
+    )
+    else {
+        return Ok(false);
+    };
+    let payload = sync_signature_payload(
+        &head.snapshot_id,
+        &head.manifest_hash,
+        head.created_at_ms,
+        author_device_id,
+        author_fingerprint,
+        author_cert_id,
+        author_chain_hash,
+    )?;
+    Ok(legacy_sync_signature(&payload) == author_signature)
+}
+
+pub fn sync_auth_readiness_target(
+    conn: &Connection,
+    target_uri: &str,
+) -> AppResult<SyncAuthReadinessReportV1> {
+    let target = SyncTargetUri::parse(target_uri)?;
+    let remote_head = match &target {
+        SyncTargetUri::FilePath { path } => FsSyncTransport::new(Path::new(path)).read_head()?,
+        SyncTargetUri::S3 { bucket, prefix } => {
+            S3SyncTransport::new(bucket.clone(), prefix.clone()).read_head()?
+        }
+    };
+    classify_sync_auth_readiness(conn, target.display(), remote_head)
+}
+
 fn sync_merge_preview_file_target(
     conn: &Connection,
     vault_path: &Path,
@@ -2353,13 +2550,16 @@ pub fn sync_pull_target_with_mode(
 #[cfg(test)]
 mod tests {
     use super::{
-        bytes_to_hex, ensure_remote_trust_matches, legacy_sync_signature, sign_sync_payload,
+        bytes_to_hex, classify_sync_auth_readiness, ensure_remote_trust_matches,
+        legacy_sync_signature, sign_sync_payload, sync_auth_readiness_target,
         sync_signature_payload, unpack_zip_snapshot, unpack_zip_snapshot_with_limits,
-        validate_snapshot_dir_limits, SyncHeadV1, SyncSnapshotResourceLimits, SyncTrustV1,
-        TRUST_MODEL_PASSPHRASE_V1,
+        validate_snapshot_dir_limits, SyncAuthReadinessClassification, SyncHeadV1,
+        SyncSnapshotResourceLimits, SyncTrustV1, TRUST_MODEL_PASSPHRASE_V1,
     };
     use crate::db::apply_migrations;
-    use crate::sync_auth::SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1;
+    use crate::sync_auth::{
+        canonical_sync_author_payload_v1, SyncAuthorPayloadV1, SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1,
+    };
     use crate::sync_key_custody::store_sync_signing_seed;
     use crate::trust::format_device_fingerprint;
     use crate::trust_identity;
@@ -2659,5 +2859,74 @@ mod tests {
 
         ensure_remote_trust_matches(&conn, Some(&head), &trust)
             .expect("undeclared v3 legacy fallback remains compatible");
+    }
+
+    #[test]
+    fn sync_auth_readiness_declared_ed25519_is_strict_ready() {
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let (conn, _trust, mut head, payload) = trusted_author_fixture(&key);
+        let signed_payload = canonical_sync_author_payload_v1(&SyncAuthorPayloadV1 {
+            snapshot_id: head.snapshot_id.clone(),
+            manifest_hash: head.manifest_hash.clone(),
+            created_at_ms: head.created_at_ms,
+            author_device_id: head.author_device_id.clone().expect("device id"),
+            author_fingerprint: head.author_fingerprint.clone().expect("fingerprint"),
+            author_cert_id: head.author_cert_id.clone().expect("cert id"),
+            author_chain_hash: head.author_chain_hash.clone().expect("chain hash"),
+        })
+        .expect("canonical payload");
+        head.author_signature = Some(bytes_to_hex(&key.sign(&signed_payload).to_bytes()));
+        head.author_signature_alg = Some(SYNC_AUTHOR_SIGNATURE_ALG_ED25519_V1.to_string());
+        assert_ne!(payload, signed_payload);
+
+        let report =
+            classify_sync_auth_readiness(&conn, "file:///tmp/sync-target".to_string(), Some(head))
+                .expect("readiness report");
+
+        assert_eq!(
+            report.classification,
+            SyncAuthReadinessClassification::DeclaredEd25519
+        );
+        assert!(report.strict_ready);
+        assert!(!report.depends_on_legacy_fallback);
+        assert!(report.remediation.is_none());
+    }
+
+    #[test]
+    fn sync_auth_readiness_undeclared_legacy_fallback_is_not_strict_ready() {
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let (conn, _trust, mut head, payload) = trusted_author_fixture(&key);
+        head.author_signature = Some(legacy_sync_signature(&payload));
+
+        let report =
+            classify_sync_auth_readiness(&conn, "file:///tmp/sync-target".to_string(), Some(head))
+                .expect("readiness report");
+
+        assert_eq!(
+            report.classification,
+            SyncAuthReadinessClassification::UndeclaredLegacyFallback
+        );
+        assert!(!report.strict_ready);
+        assert!(report.depends_on_legacy_fallback);
+        assert!(report.remediation.is_some());
+    }
+
+    #[test]
+    fn sync_auth_readiness_missing_head_is_strict_ready_without_remote_mutation() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let target = root.path().join("sync-target");
+        let conn = rusqlite::Connection::open_in_memory().expect("open db");
+
+        let report =
+            sync_auth_readiness_target(&conn, target.to_string_lossy().as_ref()).expect("report");
+
+        assert_eq!(
+            report.classification,
+            SyncAuthReadinessClassification::NoRemoteHead
+        );
+        assert!(report.strict_ready);
+        assert!(!report.depends_on_legacy_fallback);
+        assert!(report.remote_head.is_none());
+        assert!(!target.exists());
     }
 }

--- a/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
+++ b/knowledgecore-docpack/docs/19-security-readiness-checkpoint-2026-06-19.md
@@ -62,6 +62,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - S3 sync emits Ed25519 author signatures only when `KC_SYNC_AUTHOR_SIGNING_KEY_HEX` is explicitly provided and matches the verified local author device key; otherwise it preserves legacy v3 signature emission.
 - Sync head parsing now supports optional `author_signature_alg = "ed25519_sync_head_v1"` as a v3 extension. Declared Ed25519 heads must pass Ed25519 verification and cannot fall back to legacy BLAKE3-derived signatures; unknown declared algorithms fail closed.
 - Local sync signing key custody is now implemented behind explicit trust-device enrollment: schema v12 adds `sync_signing_keys`, private Ed25519 seeds are encrypted with XChaCha20-Poly1305 using the vault unlock passphrase boundary, CLI/desktop surfaces expose enrollment/status/soft-delete/rotation controls, and S3 sync emits `author_signature_alg = "ed25519_sync_head_v1"` only when the custody key is unlocked and matches the verified local author device.
+- Read-only sync auth readiness reporting is now exposed through CLI/core-service/desktop RPC and classifies remote heads without writes, migrations, fallback removal, cloud expansion, or strict-mode enforcement.
 - Recovery verification now decrypts `key_blob.enc` with the recovery phrase-derived key, checks the deterministic recovery nonce, rejects empty restored passphrases, and includes regressions for matching-hash forged blobs that cannot decrypt.
 - DB encryption lifecycle tests now pin unsupported mode/KDF rejection, idempotent already-encrypted migration detection, wrong-key failure for encrypted DB migration, and absence of stale `.sqlcipher.tmp` / `.pre-sqlcipher.bak` artifacts after successful migration.
 - SQLCipher production state semantics are captured as an approval-gated design note in `docs/21-sqlcipher-state-model-plan-2026-06-19.md`; the documented decision is a future `vault.json` v4 `db_encryption.state` boundary, with no schema or runtime behavior changed in this lane.
@@ -89,7 +90,7 @@ Capture the current security/readiness state after the June 2026 audit, first de
 - Do not promote S3 sync, managed identity, or recovery escrow to production-ready until their current risk items are resolved and verified.
 
 ## Next Recommended Lane
-1. Implement the read-only sync auth readiness report before any private-key recovery, strict-mode enforcement, or undeclared legacy fallback removal.
+1. Build compatibility fixtures and rollout evidence with the read-only sync auth readiness report before any private-key recovery, strict-mode enforcement, or undeclared legacy fallback removal.
 2. Decide whether to proceed with the v4 `db_encryption.state` schema implementation and compatibility fixtures.
 3. Decide whether non-OCR PDF page-count limits are needed beyond the current PDF byte and OCR page-count guardrails.
 4. Plan the next RustSec review before `2026-07-19`, especially the GTK3/Tauri Linux backend chain and the remaining macro/unicode transitives.

--- a/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/20-sync-authorship-hardening-plan-2026-06-19.md
@@ -33,7 +33,8 @@ Remote sync heads should be accepted only when authorship is verified against an
 4. Done: add optional algorithm parsing and strict declared-Ed25519 acceptance semantics.
 5. Done: add initial encrypted local key custody, status/delete surfaces, and declared-algorithm writer emission when the custody key is unlocked.
 6. Done: add explicit runtime rotation that enrolls a replacement signing device and retires old local custody while preserving old public trust records.
-7. Remaining: implement read-only sync auth readiness reporting, then separately approve remote trust import and the point at which undeclared legacy BLAKE3-derived author signatures become hard failures.
+7. Done: add read-only sync auth readiness reporting that classifies remote heads as declared Ed25519, undeclared Ed25519-compatible, undeclared legacy fallback, legacy schema, missing, or invalid.
+8. Remaining: separately approve remote trust import and the point at which undeclared legacy BLAKE3-derived author signatures become hard failures.
 
 ## Implementation Checkpoint
 - Added a private `kc_core::sync_auth` helper module for future Ed25519 signed-head work.
@@ -47,6 +48,7 @@ Remote sync heads should be accepted only when authorship is verified against an
 - Added CLI/core-service/desktop RPC status and soft-delete surfaces for encrypted local signing-key custody.
 - Added CLI/core-service/desktop RPC rotation surfaces that enroll a replacement signing device and mark the old local custody row rotated/deleted.
 - Added the rotation/recovery/fallback-removal decision record as `docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md`.
+- Added read-only `sync auth-readiness` CLI/core-service/desktop RPC reporting for local and URI sync targets; it performs no writes, migrations, fallback removal, cloud expansion, or strict-mode enforcement.
 - S3 sync emits declared Ed25519 heads when the custody key is available through the vault unlock/passphrase boundary.
 - No cloud behavior, remote trust bootstrapping, background sync, or legacy fallback removal changed in this checkpoint.
 

--- a/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
+++ b/knowledgecore-docpack/docs/24-sync-key-custody-and-algorithm-decision-2026-06-19.md
@@ -59,6 +59,7 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - `trust device signing-key-status` and `trust device signing-key-delete` expose custody metadata and explicit local soft-delete without printing secret material; desktop RPC mirrors those status/delete surfaces.
 - `trust device signing-key-rotate` creates a replacement signing device and certificate, stores the new encrypted seed, then marks the old local custody row rotated/deleted while leaving old public trust records readable.
 - S3 sync uses an unlocked custody key to emit declared Ed25519 heads; if no custody key exists, compatibility behavior is preserved.
+- Read-only `sync auth-readiness` CLI/core-service/desktop RPC reporting classifies local and URI sync targets without writes, migrations, fallback removal, cloud expansion, or strict-mode enforcement.
 
 ## Non-Goals
 - No cloud sync expansion.
@@ -75,7 +76,7 @@ Use vault-local encrypted key custody rather than environment variables for prod
 - Any vault metadata/schema change requires fixtures, downgrade/rollback expectations, and no private-document ingestion.
 
 ## Next Safe Lane
-Implement a read-only sync auth readiness report before any private-key recovery, schema migration, strict-mode enforcement, or undeclared legacy fallback removal.
+Build compatibility fixtures and rollout evidence with the read-only `sync auth-readiness` report before any private-key recovery, schema migration, strict-mode enforcement, or undeclared legacy fallback removal.
 
 ## Verification Expectations for the Next Code Lane
 - `cargo fmt --all -- --check`
@@ -88,4 +89,4 @@ Implement a read-only sync auth readiness report before any private-key recovery
 - `node scripts/dependency-watch.mjs`
 
 ## Done Criteria
-This lane is done when encrypted local custody, custody-signed declared S3 heads, replacement-device rotation, and compatibility fallback preservation are verified, with recovery and undeclared legacy fallback removal still approval-gated.
+This lane is done when encrypted local custody, custody-signed declared S3 heads, replacement-device rotation, read-only auth-readiness reporting, and compatibility fallback preservation are verified, with recovery and undeclared legacy fallback removal still approval-gated.

--- a/knowledgecore-docpack/docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md
+++ b/knowledgecore-docpack/docs/25-sync-signing-key-rotation-recovery-and-fallback-plan-2026-06-19.md
@@ -35,14 +35,14 @@ Recovery should be local re-enrollment, not private signing-key backup.
 ## Fallback Removal Decision
 Legacy undeclared v3 signatures can be removed only after compatibility evidence proves existing heads are not stranded.
 
-- First add read-only telemetry/reporting that classifies sync heads as declared Ed25519, undeclared Ed25519-compatible, or undeclared legacy fallback.
-- Then add a user-visible readiness command/report that lists targets still depending on undeclared legacy fallback.
+- Done: add read-only `sync auth-readiness` telemetry/reporting that classifies sync heads as declared Ed25519, undeclared Ed25519-compatible, undeclared legacy fallback, legacy schema, missing, unsupported, or invalid.
+- Done: expose a user-visible CLI/core-service/desktop RPC readiness report that lists whether a target still depends on undeclared legacy fallback.
 - Only after that evidence exists, add a separate opt-in enforcement flag or schema-version transition plan.
 - Final removal must fail undeclared legacy fallback heads with a deterministic sync-auth error and clear remediation guidance.
 
 ## Safest Implementation Sequence
 1. Done: add explicit rotation command/RPC that enrolls a new signing device and soft-deletes the old custody row only after the new key verifies.
-2. Add a read-only sync auth readiness report for local sync targets; no writes, no migrations, no cloud behavior changes.
+2. Done: add a read-only sync auth readiness report for local sync targets; no writes, no migrations, no cloud behavior changes.
 3. Add UI/CLI copy for local re-enrollment recovery when custody is missing or deleted.
 4. Add compatibility fixtures for existing undeclared v3 heads, declared Ed25519 heads, and fallback-removal failure cases.
 5. Add opt-in strict mode for rejecting undeclared legacy fallback before making it default.


### PR DESCRIPTION
## Summary
- add read-only sync auth readiness classification for remote sync heads across core, CLI, and desktop RPC
- classify missing, legacy schema, declared Ed25519, undeclared Ed25519-compatible, undeclared legacy fallback, unsupported declared algorithm, and invalid heads
- update sync-auth docs to mark readiness reporting landed while keeping strict-mode and fallback removal approval-gated

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p kc_core sync_auth_readiness
- cargo test -p kc_cli cli_sync_push_and_status_work
- cargo test -p apps_desktop_tauri rpc_sync_status_and_push
- cargo test -p apps_desktop_tauri rpc_schema_sync
- cargo test --workspace --exclude apps_desktop_tauri
- cargo test -p apps_desktop_tauri
- node scripts/audit-rust.mjs
- node scripts/dependency-watch.mjs