### PR TITLE
fix(deps): align vector index arrow types with lancedb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4675,8 +4675,6 @@ dependencies = [
 name = "kc_index"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "criterion",
  "futures",
  "kc_core",

--- a/crates/kc_index/Cargo.toml
+++ b/crates/kc_index/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-arrow-array = "58.0"
-arrow-schema = "58.0"
 futures = "0.3"
 kc_core = { path = "../kc_core" }
 lancedb = "0.31"

--- a/crates/kc_index/src/vector.rs
+++ b/crates/kc_index/src/vector.rs
@@ -1,13 +1,13 @@
 use crate::embedding::{Embedder, EmbeddingIdentity};
-use arrow_array::{
-    types::Float32Type, Array, FixedSizeListArray, Float32Array, Int64Array, RecordBatch,
-    RecordBatchIterator, RecordBatchReader, StringArray,
-};
-use arrow_schema::{DataType, Field, Schema};
 use futures::TryStreamExt;
 use kc_core::app_error::{AppError, AppResult};
 use kc_core::index_traits::{VectorCandidate, VectorIndex};
 use kc_core::types::{ChunkId, DocId};
+use lancedb::arrow::arrow_array::{
+    types::Float32Type, Array, FixedSizeListArray, Float32Array, Int64Array, RecordBatch,
+    RecordBatchIterator, RecordBatchReader, StringArray,
+};
+use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
 use lancedb::connect;
 use lancedb::query::ExecutableQuery;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary
- remove direct arrow-array and arrow-schema dependencies from kc_index
- import Arrow types through lancedb::arrow so kc_index uses the same Arrow graph as lancedb
- drop the now-redundant direct lockfile edges

## Validation
- cargo check -p kc_index
- cargo test -p kc_index
- cargo fmt --all -- --check
- git diff --check

Supersedes Dependabot PRs #167 and #168.