### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204: invalid pointer dereference in the fmt::Pointer/Display impl
for Atomic/Shared when the pointer is null/invalid. Transitive via moka; low
practical severity (no CVSS; only fires if code Display-formats a crossbeam
pointer). RustSec-only, so Dependabot never alerts or PRs it. Surgical bump;
cargo check passes.
